### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rel="noopener noreferrer" to target="_blank" links

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         <div class="teams-column">
           <h2>LTTA Tuesday Tennis – 2025</h2>
           <div>
-            <a href="teams/tuesday/all.html" target="_blank"
+            <a href="teams/tuesday/all.html" target="_blank" rel="noopener noreferrer"
               >All Team's Matches</a
             >
           </div>
@@ -90,7 +90,7 @@
         <div class="teams-column">
           <h2>LTTA Wednesday Tennis – 2025</h2>
           <div>
-            <a href="teams/wednesday/all.html" target="_blank"
+            <a href="teams/wednesday/all.html" target="_blank" rel="noopener noreferrer"
               >All Team's Matches</a
             >
           </div>

--- a/pages/ltta-rules.html
+++ b/pages/ltta-rules.html
@@ -45,7 +45,7 @@
         <ul>
           <li>
             LTTA operates under the oversight of the
-            <a href="http://www.couleeregiontennis.com" target="_blank"
+            <a href="http://www.couleeregiontennis.com" target="_blank" rel="noopener noreferrer"
               >Coulee Region Tennis Association</a
             >.
           </li>
@@ -222,7 +222,7 @@
           See the
           <a
             href="https://www.usta.com/en/home/stay-current/rules-of-tennis.html"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             >USTA Friend at Court</a
           >
           for final rulings.
@@ -361,7 +361,7 @@
         governing match rules and tennis standards, see the
         <a
           href="https://www.usta.com/content/dam/usta/2024-pdfs/friend-at-court.pdf"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
           >USTA Friend at Court</a
         >.
       </p>

--- a/pages/subs.html
+++ b/pages/subs.html
@@ -55,7 +55,7 @@
               <a
                 class="groupme-link"
                 href="https://groupme.com/join_group/107614095/EnzqFFBq"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
               >
                 Level 1 Subs
               </a>
@@ -71,7 +71,7 @@
               <a
                 class="groupme-link"
                 href="https://groupme.com/join_group/107614126/Pb9RhLpp"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
               >
                 Level 2 Subs
               </a>
@@ -87,7 +87,7 @@
               <a
                 class="groupme-link"
                 href="https://groupme.com/join_group/107613890/YP9b8Dt4"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
               >
                 Level 3 Subs
               </a>
@@ -103,7 +103,7 @@
               <a
                 class="groupme-link"
                 href="https://groupme.com/join_group/107614052/BTImdRec"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
               >
                 Level 4 & 5 Subs
               </a>

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -17,7 +17,7 @@
           <li><a href="../pages/ltta-rules.html">Rules</a></li>
           <li><a href="../pages/standings.html">Standings</a></li>
           <li>
-            <a href="http://www.couleeregiontennis.com" target="_blank"
+            <a href="http://www.couleeregiontennis.com" target="_blank" rel="noopener noreferrer"
               >CRTA Website</a
             >
           </li>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Links with `target="_blank"` without `rel="noopener noreferrer"` are vulnerable to reverse tabnabbing. The target page gets access to the source page's `window` object via `window.opener`, allowing it to potentially redirect the source page to a malicious site.
🎯 Impact: If any of the external links are compromised, they could redirect the users of this application to a phishing page.
🔧 Fix: Added `rel="noopener noreferrer"` to all `target="_blank"` links in the codebase (`partials/nav.html`, `pages/ltta-rules.html`, `pages/subs.html`, `index.html`).
✅ Verification: Ran `npx playwright test` to ensure basic functionality is still working. Checked the code with `grep target= .` to ensure the fix was properly applied to all occurrences.

---
*PR created automatically by Jules for task [16267500823248669020](https://jules.google.com/task/16267500823248669020) started by @BLMeddaugh*