### PR TITLE
Refactor Playwright test suites for stability with strict locators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "couleeregiontennis.github.io",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -12,17 +12,17 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
-        "@playwright/test": "^1.58.2"
+        "@playwright/test": "^1.59.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -139,13 +139,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2"
+    "@playwright/test": "^1.59.1"
   }
 }

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -3,7 +3,7 @@ const { test, expect } = require('@playwright/test');
 test.describe('Home Page', () => {
     test('should display the main header', async ({ page }) => {
         await page.goto('/');
-        await expect(page.locator('h1').first()).toHaveText('Teams');
+        await expect(page.getByRole('heading', { level: 1, name: 'Teams' })).toBeVisible();
     });
 
     test('should display both league sections', async ({ page }) => {
@@ -16,7 +16,7 @@ test.describe('Home Page', () => {
         await page.goto('/');
 
         // Click on Team 1 for Tuesday
-        await page.click('text=Team 1 – Spin Doctors');
+        await page.getByRole('link', { name: 'Team 1 – Spin Doctors' }).click();
 
         // Verify it navigates to the correct URL
         await expect(page).toHaveURL(/.*pages\/team\.html\?day=tuesday&team=1/);

--- a/tests/static-pages.spec.js
+++ b/tests/static-pages.spec.js
@@ -3,17 +3,17 @@ const { test, expect } = require('@playwright/test');
 test.describe('Static Pages', () => {
     test('Standings page renders correctly', async ({ page }) => {
         await page.goto('/pages/standings.html');
-        await expect(page.locator('h1').first()).toContainText('Standings');
+        await expect(page.getByRole('heading', { level: 1, name: 'Standings' })).toBeVisible();
     });
 
     test('Subs page renders correctly', async ({ page }) => {
         await page.goto('/pages/subs.html');
-        await expect(page.locator('h1').first()).toContainText('LTTA Sub GroupMe Links');
+        await expect(page.getByRole('heading', { level: 1, name: 'LTTA Sub GroupMe Links' })).toBeVisible();
     });
 
     test('Rules page renders correctly', async ({ page }) => {
         await page.goto('/pages/ltta-rules.html');
         // The rules page usually has a specific header or title.
-        await expect(page.locator('h1').first()).toBeVisible();
+        await expect(page.getByRole('heading', { level: 1, name: 'La Crosse Team Tennis Association (LTTA) – Summer League 2025' })).toBeVisible();
     });
 });

--- a/tests/team.spec.js
+++ b/tests/team.spec.js
@@ -13,7 +13,7 @@ test.describe('Team Page', () => {
         await expect(matchRows).not.toHaveCount(0);
 
         // Check if table headers exist
-        await expect(page.locator('#matches-table th').first()).toHaveText('Week');
+        await expect(page.getByRole('columnheader', { name: 'Week' })).toBeVisible();
     });
 
     test('should handle missing URL parameters gracefully', async ({ page }) => {


### PR DESCRIPTION
This pull request addresses flaky tests and lazy waits by implementing resilient locators and strict assertions across the Playwright test suite. I replaced brittle selectors (such as `.first()` and `text=...`) with Playwright's officially recommended accessibility-first locators (`getByRole`). The test cases in `home.spec.js`, `static-pages.spec.js`, and `team.spec.js` have been refactored, and all modified tests passed upon execution. Additionally, I ensured that the `@playwright/test` dependency was properly available for local execution.

---
*PR created automatically by Jules for task [1641936559213125165](https://jules.google.com/task/1641936559213125165) started by @BLMeddaugh*