### PR TITLE
Nemesis Prime Audit: Rejected Sentinel XSS MR

### DIFF
--- a/SYSTEM_LOG.md
+++ b/SYSTEM_LOG.md
@@ -1,0 +1,1 @@
+- Context-blind generic escaping in URL attributes: Using escapeHTML for href attributes does not prevent javascript: URI schemes, leaving DOM-based XSS vectors open.

--- a/SYSTEM_LOG.md
+++ b/SYSTEM_LOG.md
@@ -1,1 +1,13 @@
-- Context-blind generic escaping in URL attributes: Using escapeHTML for href attributes does not prevent javascript: URI schemes, leaving DOM-based XSS vectors open.
+# Automated Auditor System Log
+
+## 2025-05-XX - XSS Sanitization Bypass via HTML Entities
+**Vulnerability:** A bot (Sentinel) attempted to implement a `sanitizeUrl` function to block `javascript:`, `data:`, and `vbscript:` schemes using `startsWith()`. However, when this sanitized URL is injected into the DOM via `innerHTML` (e.g., `href="${sanitizeUrl(url)}"`), the browser's HTML parser decodes HTML entities *before* evaluating the URL scheme. An attacker can supply `javascript&#58;alert(1)` which bypasses the `startsWith('javascript:')` check but executes successfully in the browser.
+**Learning:** URL sanitizers must decode HTML entities and strip control characters/whitespaces before validating the scheme, or better yet, parse the URL using the `URL` API and check the `.protocol` property.
+
+## 2025-05-XX - Reverse Tabnabbing Regression in Audit
+**Vulnerability:** A bot (Jules) performed an audit and explicitly removed `rel="noopener noreferrer"` from `target="_blank"` anchor tags. This reintroduced a reverse tabnabbing security vulnerability.
+**Learning:** Automated auditors can suffer from destructive confirmation bias, removing essential security attributes if they don't understand their purpose. Security invariants must be hardcoded in memory/checklists for future bots.
+
+## 2025-05-XX - Context-blind generic escaping in URL attributes
+**Vulnerability:** Using escapeHTML for href attributes does not prevent javascript: URI schemes, leaving DOM-based XSS vectors open.
+**Learning:** When using innerHTML, escapeHTML prevents breaking out of quotes, but does not sanitize URL attributes. Context-aware sanitization must be applied to URLs.

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         <div class="teams-column">
           <h2>LTTA Tuesday Tennis – 2025</h2>
           <div>
-            <a href="teams/tuesday/all.html" target="_blank"
+            <a href="teams/tuesday/all.html" target="_blank" rel="noopener noreferrer"
               >All Team's Matches</a
             >
           </div>
@@ -90,7 +90,7 @@
         <div class="teams-column">
           <h2>LTTA Wednesday Tennis – 2025</h2>
           <div>
-            <a href="teams/wednesday/all.html" target="_blank"
+            <a href="teams/wednesday/all.html" target="_blank" rel="noopener noreferrer"
               >All Team's Matches</a
             >
           </div>

--- a/management-scripts/create-emails.js
+++ b/management-scripts/create-emails.js
@@ -1,15 +1,15 @@
 const fs = require('fs');
 const path = require('path');
-const csv = require('csv-parser');
+const { parse } = require('csv-parse/sync');
 const { fetchCSV } = require('./fetch-csv');
 
-const OUTPUT_DIR = '../output_emails';
+const OUTPUT_DIR = path.join(__dirname, '..', 'output_emails');
 
 const CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRlgS5yGzip6doLKqud9BDdpCt1_8CPWNjUxFmYgVdkdbQ_MNIc1ku1GJoZ2NBEuw/pub?gid=270023155&single=true&output=csv';
 
 // Ensure output directory exists
 if (!fs.existsSync(OUTPUT_DIR)) {
-  fs.mkdirSync(OUTPUT_DIR);
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
 }
 
 const coordinator = {
@@ -41,12 +41,14 @@ async function main() {
     console.log('Fetched CSV data successfully');
     
     // Parse CSV content
-    const records = [];
-    const parser = csv({
-      mapValues: ({ header, value }) => value.trim()
+    const parsedData = parse(csvContent, {
+      columns: true,
+      skip_empty_lines: true,
+      trim: true
     });
 
-    parser.on('data', (data) => {
+    const records = [];
+    parsedData.forEach((data) => {
       // Map new column names to expected format
       const record = {
         Night: data.Night,
@@ -60,9 +62,8 @@ async function main() {
       records.push(record);
     });
 
-    parser.on('end', () => {
-      // Group players by team
-      records.forEach(record => {
+    // Group players by team
+    records.forEach(record => {
         if (!record.Night || !record.Team || !record.Name) {
           console.warn('Skipping incomplete record:', record);
           return;
@@ -221,10 +222,6 @@ async function main() {
         fs.writeFileSync(fileName, emailContent, 'utf8');
         console.log(`✅ Created email for ${night} Team ${teamNumber} – ${fileName}`);
       });
-    });
-    
-    parser.write(csvContent);
-    parser.end();
 
   } catch (error) {
     console.error('Error processing CSV:', error);

--- a/management-scripts/generate-rr.js
+++ b/management-scripts/generate-rr.js
@@ -1,10 +1,10 @@
-const XLSX = require('xlsx');
+const { parse } = require('csv-parse/sync');
 const fs = require('fs');
 const path = require('path');
 const { fetchCSV } = require('./fetch-csv');
 
 // CONFIG
-const OUTPUT_DIR = '../teams';
+const OUTPUT_DIR = path.join(__dirname, '../teams');
 const START_DATE = '2025-06-03'; // Change as needed
 const COURT_GROUPS = ["Courts 1–5", "Courts 6–9", "Courts 10–13"];
 const TIMES = ["5:30pm", "7:00pm"];
@@ -25,27 +25,26 @@ async function loadSheet() {
     const csvContent = await fetchCSV(CSV_URL);
     console.log('CSV data fetched successfully');
     
-    // Create workbook from CSV
-    const wb = XLSX.read(csvContent, { 
-      type: 'string',
-      raw: true,
-      cellDates: true,
-      dateNF: 'yyyy-mm-dd'
+    // Parse CSV content using csv-parse/sync
+    const rawRows = parse(csvContent, {
+      columns: false,
+      skip_empty_lines: true
     });
-    
-    const ws = wb.Sheets[wb.SheetNames[0]];
-    const rows = XLSX.utils.sheet_to_json(ws, { 
-      raw: false,
-      defval: '',
-      header: [
-        'Night',
-        'Team/',
-        'C/CC',
-        'Level',
-        '1-Name',
-        'TEAM NAME'
-      ]
-    });
+
+    // Convert parsed arrays to objects matching the expected format
+    const rows = [];
+    for (let i = 0; i < rawRows.length; i++) {
+      const row = rawRows[i];
+      rows.push({
+        'Night': row[0] || '',
+        'Team/': row[1] || '',
+        'C/CC': row[2] || '',
+        'Level': row[3] || '',
+        '1-Name': row[4] || '',
+        'TEAM NAME': row[5] || ''
+      });
+    }
+
 
     console.log(`Parsed ${rows.length} rows from CSV`);
     return rows;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "couleeregiontennis.github.io",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -7,8 +7,6 @@
       "dependencies": {
         "csv-parse": "^5.6.0",
         "csv-parser": "^3.2.0",
-        "fs": "^0.0.1-security",
-        "path": "^0.12.7",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -101,12 +99,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -120,22 +112,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "license": "ISC"
-    },
-    "node_modules/path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
       }
     },
     "node_modules/playwright": {
@@ -170,15 +146,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/ssf": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
@@ -189,15 +156,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "2.0.3"
       }
     },
     "node_modules/wmf": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,23 +4,19 @@
   "requires": true,
   "packages": {
     "": {
-      "dependencies": {
-        "csv-parse": "^5.6.0",
-        "csv-parser": "^3.2.0",
-        "xlsx": "^0.18.5"
-      },
       "devDependencies": {
-        "@playwright/test": "^1.58.2"
+        "@playwright/test": "^1.59.1",
+        "csv-parse": "^6.2.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -29,75 +25,12 @@
         "node": ">=18"
       }
     },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/csv-parse": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
-      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/csv-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.2.0.tgz",
-      "integrity": "sha512-fgKbp+AJbn1h2dcAHKIdKNSSjfp43BZZykXsCjzALjKy80VXQNHPFJ6T9Afwdzoj24aMkq8GwDS7KGcDPpejrA==",
-      "license": "MIT",
-      "bin": {
-        "csv-parser": "bin/csv-parser"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -115,13 +48,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -134,9 +67,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -144,57 +77,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,6 @@
   "dependencies": {
     "csv-parse": "^5.6.0",
     "csv-parser": "^3.2.0",
-    "fs": "^0.0.1-security",
-    "path": "^0.12.7",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
-  "dependencies": {
-    "csv-parse": "^5.6.0",
-    "csv-parser": "^3.2.0",
-    "xlsx": "^0.18.5"
-  },
   "devDependencies": {
-    "@playwright/test": "^1.58.2"
+    "@playwright/test": "^1.59.1",
+    "csv-parse": "^6.2.1"
   }
 }

--- a/pages/ltta-rules.html
+++ b/pages/ltta-rules.html
@@ -45,7 +45,7 @@
         <ul>
           <li>
             LTTA operates under the oversight of the
-            <a href="http://www.couleeregiontennis.com" target="_blank"
+            <a href="http://www.couleeregiontennis.com" target="_blank" rel="noopener noreferrer"
               >Coulee Region Tennis Association</a
             >.
           </li>
@@ -222,7 +222,7 @@
           See the
           <a
             href="https://www.usta.com/en/home/stay-current/rules-of-tennis.html"
-            target="_blank"
+            target="_blank" rel="noopener noreferrer"
             >USTA Friend at Court</a
           >
           for final rulings.
@@ -361,7 +361,7 @@
         governing match rules and tennis standards, see the
         <a
           href="https://www.usta.com/content/dam/usta/2024-pdfs/friend-at-court.pdf"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
           >USTA Friend at Court</a
         >.
       </p>

--- a/pages/subs.html
+++ b/pages/subs.html
@@ -55,7 +55,7 @@
               <a
                 class="groupme-link"
                 href="https://groupme.com/join_group/107614095/EnzqFFBq"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
               >
                 Level 1 Subs
               </a>
@@ -71,7 +71,7 @@
               <a
                 class="groupme-link"
                 href="https://groupme.com/join_group/107614126/Pb9RhLpp"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
               >
                 Level 2 Subs
               </a>
@@ -87,7 +87,7 @@
               <a
                 class="groupme-link"
                 href="https://groupme.com/join_group/107613890/YP9b8Dt4"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
               >
                 Level 3 Subs
               </a>
@@ -103,7 +103,7 @@
               <a
                 class="groupme-link"
                 href="https://groupme.com/join_group/107614052/BTImdRec"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
               >
                 Level 4 & 5 Subs
               </a>

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -17,7 +17,7 @@
           <li><a href="../pages/ltta-rules.html">Rules</a></li>
           <li><a href="../pages/standings.html">Standings</a></li>
           <li>
-            <a href="http://www.couleeregiontennis.com" target="_blank"
+            <a href="http://www.couleeregiontennis.com" target="_blank" rel="noopener noreferrer"
               >CRTA Website</a
             >
           </li>

--- a/scripts/standings.js
+++ b/scripts/standings.js
@@ -1,4 +1,14 @@
 const CSV_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQ09FIuDMkX5mmdp9e-szR15pWx2cp-YyqsYxoNBL4FM0y8v3Q_LKboCjAEcUyobbgwCCGQpSMT3bXh/pub?output=csv";
+function escapeHTML(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 fetch(CSV_URL)
   .then(res => res.text())
   .then(csv => {
@@ -21,7 +31,7 @@ fetch(CSV_URL)
     }
 
     // Header
-    thead.innerHTML = '<tr>' + rows[0].map(h => `<th>${h}</th>`).join('') + '</tr>';
+    thead.innerHTML = '<tr>' + rows[0].map(h => `<th>${escapeHTML(h)}</th>`).join('') + '</tr>';
 
     // Find the "ranks" and "Night" column indices (case-insensitive)
     const totalIdx = rows[0].findIndex(h => h.trim().toLowerCase() === "rank");
@@ -39,8 +49,8 @@ fetch(CSV_URL)
         return aVal - bVal;
       });
       tbody.innerHTML = sortedRows.map(row =>
-        `<tr data-night="${row[nightIdx].toLowerCase()}">` + 
-        row.map(cell => `<td>${cell}</td>`).join('') + 
+        `<tr data-night="${escapeHTML(row[nightIdx].toLowerCase())}">` +
+        row.map(cell => `<td>${escapeHTML(cell)}</td>`).join('') +
         '</tr>'
       ).join('');
     }

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -17,10 +17,15 @@ async function loadTeamData(scheduleUrl, rosterUrl) {
   if (!tableBody || !rosterBody) return;
 
   try {
-    const scheduleResponse = await fetch(scheduleUrl);
-    const scheduleData = await scheduleResponse.json();
-    const rosterResponse = await fetch(rosterUrl);
-    const rosterData = await rosterResponse.json();
+    // ⚡ Bolt: Parallelize schedule and roster data fetches to reduce wait time
+    const [scheduleResponse, rosterResponse] = await Promise.all([
+      fetch(scheduleUrl),
+      fetch(rosterUrl)
+    ]);
+    const [scheduleData, rosterData] = await Promise.all([
+      scheduleResponse.json(),
+      rosterResponse.json()
+    ]);
 
     // Update header with team name if available
     if (header && rosterData.teamName) header.textContent = rosterData.teamName;

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -1,4 +1,15 @@
 // This script dynamically loads match and roster data into tables and highlights the next match
+function escapeHTML(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// This script dynamically loads match and roster data into tables and highlights the next match
 async function loadTeamData(scheduleUrl, rosterUrl) {
   const tableBody = document.querySelector("#matches-table tbody");
   const rosterBody = document.querySelector("table:not(#matches-table) tbody");
@@ -22,13 +33,13 @@ async function loadTeamData(scheduleUrl, rosterUrl) {
         : '';
       const tr = document.createElement("tr");
       tr.innerHTML = `
-        <td>${match.week}</td>
-        <td>${formatDateUS(match.date)}</td>
-        <td>${match.time}</td>
+        <td>${escapeHTML(match.week)}</td>
+        <td>${escapeHTML(formatDateUS(match.date))}</td>
+        <td>${escapeHTML(match.time)}</td>
         <td>
-          <a href="${match.opponent.file}" class="team-link">${match.opponent.name}</a>
+          <a href="${escapeHTML(match.opponent.file)}" class="team-link">${escapeHTML(match.opponent.name)}</a>
         </td>
-        <td>${match.courts}</td>
+        <td>${escapeHTML(match.courts)}</td>
         <td style="text-align:center">${icsLink}</td>
       `;
       tableBody.appendChild(tr);
@@ -39,9 +50,9 @@ async function loadTeamData(scheduleUrl, rosterUrl) {
     (rosterData.roster || []).forEach(player => {
       const tr = document.createElement("tr");
       tr.innerHTML = `
-        <td>${player.position}</td>
-        <td>${player.name}</td>
-        <td>${player.captain || ""}</td>
+        <td>${escapeHTML(player.position)}</td>
+        <td>${escapeHTML(player.name)}</td>
+        <td>${escapeHTML(player.captain || "")}</td>
       `;
       rosterBody.appendChild(tr);
     });

--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -3,25 +3,25 @@ const { test, expect } = require('@playwright/test');
 test.describe('Home Page', () => {
     test('should display the main header', async ({ page }) => {
         await page.goto('/');
-        await expect(page.locator('h1').first()).toHaveText('Teams');
+        await expect(page.getByRole('heading', { level: 1, name: 'Teams', exact: true })).toBeVisible();
     });
 
     test('should display both league sections', async ({ page }) => {
         await page.goto('/');
-        await expect(page.getByRole('heading', { name: 'LTTA Tuesday Tennis – 2025' })).toBeVisible();
-        await expect(page.getByRole('heading', { name: 'LTTA Wednesday Tennis – 2025' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'LTTA Tuesday Tennis – 2025', level: 2 })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'LTTA Wednesday Tennis – 2025', level: 2 })).toBeVisible();
     });
 
     test('should navigate to team page when clicking a team link', async ({ page }) => {
         await page.goto('/');
 
         // Click on Team 1 for Tuesday
-        await page.click('text=Team 1 – Spin Doctors');
+        await page.getByRole('link', { name: 'Team 1 – Spin Doctors' }).click();
 
         // Verify it navigates to the correct URL
         await expect(page).toHaveURL(/.*pages\/team\.html\?day=tuesday&team=1/);
 
         // Verify the team name is visible on the new page
-        await expect(page.locator('#team-name')).toBeVisible();
+        await expect(page.getByRole('heading', { level: 1, name: 'Spin Doctors' })).toBeVisible();
     });
 });

--- a/tests/static-pages.spec.js
+++ b/tests/static-pages.spec.js
@@ -2,18 +2,54 @@ const { test, expect } = require('@playwright/test');
 
 test.describe('Static Pages', () => {
     test('Standings page renders correctly', async ({ page }) => {
+        const mockCsvData = "Rank,Night,Team\n1,Tuesday,Team A\n2,Wednesday,Team B\n3,Tuesday,Team C";
+        await page.route('https://docs.google.com/spreadsheets/d/e/2PACX-1vQ09FIuDMkX5mmdp9e-szR15pWx2cp-YyqsYxoNBL4FM0y8v3Q_LKboCjAEcUyobbgwCCGQpSMT3bXh/pub?output=csv', async route => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'text/csv',
+                body: mockCsvData,
+            });
+        });
+
         await page.goto('/pages/standings.html');
-        await expect(page.locator('h1').first()).toContainText('Standings');
+        await expect(page.getByRole('heading', { level: 1, name: 'Standings' })).toBeVisible();
+
+        // Verify initial render (All)
+        const teamARow = page.getByRole('row', { name: '1 Tuesday Team A' });
+        const teamBRow = page.getByRole('row', { name: '2 Wednesday Team B' });
+        const teamCRow = page.getByRole('row', { name: '3 Tuesday Team C' });
+
+        await expect(teamARow).toBeVisible();
+        await expect(teamBRow).toBeVisible();
+        await expect(teamCRow).toBeVisible();
+
+        // Test Tuesday filter
+        await page.getByRole('button', { name: 'Tuesday' }).click();
+        await expect(teamARow).toBeVisible();
+        await expect(teamBRow).not.toBeVisible();
+        await expect(teamCRow).toBeVisible();
+
+        // Test Wednesday filter
+        await page.getByRole('button', { name: 'Wednesday' }).click();
+        await expect(teamARow).not.toBeVisible();
+        await expect(teamBRow).toBeVisible();
+        await expect(teamCRow).not.toBeVisible();
+
+        // Test All filter
+        await page.getByRole('button', { name: 'All' }).click();
+        await expect(teamARow).toBeVisible();
+        await expect(teamBRow).toBeVisible();
+        await expect(teamCRow).toBeVisible();
     });
 
     test('Subs page renders correctly', async ({ page }) => {
         await page.goto('/pages/subs.html');
-        await expect(page.locator('h1').first()).toContainText('LTTA Sub GroupMe Links');
+        await expect(page.getByRole('heading', { level: 1, name: 'LTTA Sub GroupMe Links' })).toBeVisible();
     });
 
     test('Rules page renders correctly', async ({ page }) => {
         await page.goto('/pages/ltta-rules.html');
         // The rules page usually has a specific header or title.
-        await expect(page.locator('h1').first()).toBeVisible();
+        await expect(page.getByRole('heading', { level: 1, name: 'La Crosse Team Tennis Association (LTTA) – Summer League 2025' })).toBeVisible();
     });
 });

--- a/tests/team.spec.js
+++ b/tests/team.spec.js
@@ -6,21 +6,31 @@ test.describe('Team Page', () => {
         await page.goto('/pages/team.html?day=tuesday&team=1');
 
         // Wait for the JS to populate the header
-        await expect(page.locator('#team-name')).toHaveText('Spin Doctors');
+        await expect(page.getByRole('heading', { level: 1, name: 'Spin Doctors' })).toBeVisible();
 
         // Wait for the match schedule rows to populate
-        const matchRows = page.locator('#matches-table tbody tr');
-        await expect(matchRows).not.toHaveCount(0);
+        // We wait for the table row to be visible instead of using a lazy `not.toHaveCount(0)` wait
+        await expect(page.locator('#matches-table').getByRole('row').nth(1)).toBeVisible();
+
+        // Wait for the Team Roster rows to populate
+        await expect(page.locator('table:not(#matches-table)').getByRole('row').nth(1)).toBeVisible();
 
         // Check if table headers exist
-        await expect(page.locator('#matches-table th').first()).toHaveText('Week');
+        await expect(page.getByRole('columnheader', { name: 'Week' })).toBeVisible();
+    });
+
+    test('should display error messages when match or roster data fails to load', async ({ page }) => {
+        await page.goto('/pages/team.html?day=tuesday&team=invalid');
+
+        await expect(page.getByRole('cell', { name: /Could not load match data\./i })).toBeVisible();
+        await expect(page.getByRole('cell', { name: /Could not load roster data\./i })).toBeVisible();
     });
 
     test('should handle missing URL parameters gracefully', async ({ page }) => {
-        await page.goto('/pages/team.html');
+        await page.goto('/pages/team.html?day=invalid&team=invalid');
 
-        // Depending on the implementation, it might show "Team not found" or leave it empty.
-        // For now, let's just assert the page loads without crashing the core layout.
-        await expect(page.locator('h2').filter({ hasText: 'Match Schedule' })).toBeVisible();
+        await expect(page.getByRole('heading', { level: 2, name: 'Match Schedule' })).toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Could not load match data.', exact: true })).toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Could not load roster data.', exact: true })).toBeVisible();
     });
 });


### PR DESCRIPTION
Audited the automated bot MR branch `sentinel-fix-xss-and-deps-13062800629788707986` as Nemesis Prime. Found that while the bot correctly removed built-in node modules, its implementation of `escapeHTML` for mitigating XSS is insufficient for URL attributes (e.g. `href`), leaving a DOM-based XSS attack vector open via `javascript:` payloads. Additionally, some properties like `match.ics` were left completely unescaped. 

I've logged this novel failure to `SYSTEM_LOG.md` and responded to the user rejecting the MR.

---
*PR created automatically by Jules for task [15410504264786376684](https://jules.google.com/task/15410504264786376684) started by @BLMeddaugh*