### PR TITLE
⚡ Bolt: Parallelize team data network requests

### DIFF
--- a/scripts/team.js
+++ b/scripts/team.js
@@ -6,10 +6,15 @@ async function loadTeamData(scheduleUrl, rosterUrl) {
   if (!tableBody || !rosterBody) return;
 
   try {
-    const scheduleResponse = await fetch(scheduleUrl);
-    const scheduleData = await scheduleResponse.json();
-    const rosterResponse = await fetch(rosterUrl);
-    const rosterData = await rosterResponse.json();
+    // ⚡ Bolt: Parallelize schedule and roster data fetches to reduce wait time
+    const [scheduleResponse, rosterResponse] = await Promise.all([
+      fetch(scheduleUrl),
+      fetch(rosterUrl)
+    ]);
+    const [scheduleData, rosterData] = await Promise.all([
+      scheduleResponse.json(),
+      rosterResponse.json()
+    ]);
 
     // Update header with team name if available
     if (header && rosterData.teamName) header.textContent = rosterData.teamName;


### PR DESCRIPTION
💡 What: Used Promise.all to fetch scheduleUrl and rosterUrl simultaneously instead of sequentially.
🎯 Why: To reduce the overall network wait time when loading team data, improving page load performance.
📊 Impact: Expected to cut network wait time in half (assuming similar latency for both requests).
🔬 Measurement: Verify by loading a team page and checking the network tab for parallel requests, or run 'npx playwright test' to ensure functionality is preserved.

---
*PR created automatically by Jules for task [6697502679744251534](https://jules.google.com/task/6697502679744251534) started by @BLMeddaugh*