### PR TITLE
test: Refactor Playwright tests with strict locators and better coverage

### DIFF
--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -22,6 +22,6 @@ test.describe('Home Page', () => {
         await expect(page).toHaveURL(/.*pages\/team\.html\?day=tuesday&team=1/);
 
         // Verify the team name is visible on the new page
-        await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+        await expect(page.getByRole('heading', { level: 1, name: 'Spin Doctors' })).toBeVisible();
     });
 });

--- a/tests/static-pages.spec.js
+++ b/tests/static-pages.spec.js
@@ -16,4 +16,9 @@ test.describe('Static Pages', () => {
         // The rules page usually has a specific header or title.
         await expect(page.getByRole('heading', { level: 1, name: 'La Crosse Team Tennis Association (LTTA) – Summer League 2025' })).toBeVisible();
     });
+
+    test('Green Island page renders correctly', async ({ page }) => {
+        await page.goto('/pages/greenisland.html');
+        await expect(page.getByRole('heading', { level: 1, name: 'Green Island' })).toBeVisible();
+    });
 });

--- a/tests/team.spec.js
+++ b/tests/team.spec.js
@@ -10,10 +10,13 @@ test.describe('Team Page', () => {
 
         // Wait for the match schedule rows to populate
         // We wait for the table row to be visible instead of using a lazy `not.toHaveCount(0)` wait
-        await expect(page.locator('#matches-table tbody tr').nth(0)).toBeVisible();
+        await expect(page.locator('#matches-table tbody').getByRole('row').nth(0)).toBeVisible();
 
         // Check if table headers exist
         await expect(page.getByRole('columnheader', { name: 'Week' })).toBeVisible();
+
+        // Check if roster table is populated
+        await expect(page.locator('table:not(#matches-table) tbody').getByRole('row').nth(0)).toBeVisible();
     });
 
     test('should handle missing URL parameters gracefully', async ({ page }) => {


### PR DESCRIPTION
- Replaced generic heading check in home.spec.js with exact name
- Added test for greenisland.html in static-pages.spec.js
- Refactored team.spec.js to use accessible getByRole locators and verified roster render

---
*PR created automatically by Jules for task [13628549973445233902](https://jules.google.com/task/13628549973445233902) started by @BLMeddaugh*