### PR TITLE
test: stabilize playwright test locators and assertions

### DIFF
--- a/tests/home.spec.js
+++ b/tests/home.spec.js
@@ -22,6 +22,6 @@ test.describe('Home Page', () => {
         await expect(page).toHaveURL(/.*pages\/team\.html\?day=tuesday&team=1/);
 
         // Verify the team name is visible on the new page
-        await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+        await expect(page.getByRole('heading', { level: 1, name: 'Spin Doctors' })).toBeVisible();
     });
 });

--- a/tests/team.spec.js
+++ b/tests/team.spec.js
@@ -10,10 +10,20 @@ test.describe('Team Page', () => {
 
         // Wait for the match schedule rows to populate
         // We wait for the table row to be visible instead of using a lazy `not.toHaveCount(0)` wait
-        await expect(page.locator('#matches-table tbody tr').nth(0)).toBeVisible();
+        await expect(page.locator('#matches-table').getByRole('row').nth(1)).toBeVisible();
+
+        // Wait for the Team Roster rows to populate
+        await expect(page.locator('table:not(#matches-table)').getByRole('row').nth(1)).toBeVisible();
 
         // Check if table headers exist
         await expect(page.getByRole('columnheader', { name: 'Week' })).toBeVisible();
+    });
+
+    test('should display error messages when match or roster data fails to load', async ({ page }) => {
+        await page.goto('/pages/team.html?day=tuesday&team=invalid');
+
+        await expect(page.getByRole('cell', { name: /Could not load match data\./i })).toBeVisible();
+        await expect(page.getByRole('cell', { name: /Could not load roster data\./i })).toBeVisible();
     });
 
     test('should handle missing URL parameters gracefully', async ({ page }) => {


### PR DESCRIPTION
This patch addresses flaky UI tests by acting as a two-agent team (QA and SDET Critic). 

Specifically, it refactors Playwright test suites to:
- Use strict, text-based assertions instead of relying on generic tags (e.g. `getByRole('heading', { name: 'Spin Doctors' })`).
- Utilize accessibility-first `getByRole` locators over brittle CSS paths (e.g. replacing `#matches-table tbody tr` with `#matches-table .getByRole('row')`).
- Introduce error state verification, checking fallback text when JSON match/roster data fails to load due to an invalid URL (`team=invalid`).

---
*PR created automatically by Jules for task [2411831611645629233](https://jules.google.com/task/2411831611645629233) started by @BLMeddaugh*