### PR TITLE
test: stabilize team page e2e tests and add ics download coverage

### DIFF
--- a/tests/team.spec.js
+++ b/tests/team.spec.js
@@ -10,13 +10,27 @@ test.describe('Team Page', () => {
 
         // Wait for the match schedule rows to populate
         // We wait for the table row to be visible instead of using a lazy `not.toHaveCount(0)` wait
-        await expect(page.locator('#matches-table').getByRole('row').nth(1)).toBeVisible();
+        const matchesTable = page.getByRole('table').filter({ has: page.getByRole('columnheader', { name: 'Opponent' }) });
+        await expect(matchesTable.getByRole('row').nth(1)).toBeVisible();
 
         // Wait for the Team Roster rows to populate
-        await expect(page.locator('table:not(#matches-table)').getByRole('row').nth(1)).toBeVisible();
+        const rosterTable = page.getByRole('table').filter({ has: page.getByRole('columnheader', { name: 'Position' }) });
+        await expect(rosterTable.getByRole('row').nth(1)).toBeVisible();
 
         // Check if table headers exist
         await expect(page.getByRole('columnheader', { name: 'Week' })).toBeVisible();
+    });
+
+    test('should allow downloading the full season calendar', async ({ page }) => {
+        await page.goto('/pages/team.html?day=tuesday&team=1');
+
+        await expect(page.getByRole('heading', { level: 1, name: 'Spin Doctors' })).toBeVisible();
+
+        const downloadPromise = page.waitForEvent('download');
+        await page.getByRole('link', { name: /Download Full Season/i }).click();
+        const download = await downloadPromise;
+
+        expect(download.suggestedFilename()).toBe('team.ics');
     });
 
     test('should display error messages when match or roster data fails to load', async ({ page }) => {


### PR DESCRIPTION
This patch addresses the user's request to stabilize Playwright tests, remove lazy waits, and improve coverage acting as a two-agent team. It refactors `tests/team.spec.js` to use `getByRole` locators filtered by column headers for maximum resilience instead of relying on brittle DOM structure or IDs. It also adds a test for the 'Download Full Season' ICS feature.

---
*PR created automatically by Jules for task [13245228635913510966](https://jules.google.com/task/13245228635913510966) started by @BLMeddaugh*