### PR TITLE
Fix extra blank page when printing schedule

### DIFF
--- a/management-scripts/generate-all-html.js
+++ b/management-scripts/generate-all-html.js
@@ -145,7 +145,7 @@ let html = `<!DOCTYPE html>
           margin: 3px 0 5px 0;
         }
         .schedule-table {
-          page-break-after: always;
+          page-break-after: auto;
         }
       }
       /* Mobile-friendly styles */

--- a/teams/tuesday/all.html
+++ b/teams/tuesday/all.html
@@ -29,7 +29,7 @@
           margin: 3px 0 5px 0;
         }
         .schedule-table {
-          page-break-after: always;
+          page-break-after: auto;
         }
       }
       /* Mobile-friendly styles */
@@ -320,6 +320,6 @@
         <td class="match-cell"><span class="team-num">5</span>Racquet Scientists (h) vs <span class="team-num">10</span>Jetsetters<br></td>
       </tr>
     </table>
-    <p style="text-align:center; font-size: 0.8em; color: #999;">Last Updated: 4/18/2026, 2:41:08 PM</p>
+    <p style="text-align:center; font-size: 0.8em; color: #999;">Last Updated: 4/20/2026, 2:27:57 AM</p>
   </body>
 </html>

--- a/teams/wednesday/all.html
+++ b/teams/wednesday/all.html
@@ -29,7 +29,7 @@
           margin: 3px 0 5px 0;
         }
         .schedule-table {
-          page-break-after: always;
+          page-break-after: auto;
         }
       }
       /* Mobile-friendly styles */
@@ -320,6 +320,6 @@
         <td class="match-cell"><span class="team-num">5</span>Glory Days (h) vs <span class="team-num">10</span>Backhand Bandits<br></td>
       </tr>
     </table>
-    <p style="text-align:center; font-size: 0.8em; color: #999;">Last Updated: 4/18/2026, 2:41:09 PM</p>
+    <p style="text-align:center; font-size: 0.8em; color: #999;">Last Updated: 4/20/2026, 2:27:57 AM</p>
   </body>
 </html>


### PR DESCRIPTION
Changed page-break-after from always to auto for the schedule-table class in generate-all-html.js, and regenerated tuesday and wednesday schedule pages.

---
*PR created automatically by Jules for task [16871036426670584616](https://jules.google.com/task/16871036426670584616) started by @BLMeddaugh*