### PR TITLE
chore: remove Logan court override and update all matches to Green Island

### DIFF
--- a/.gemini
+++ b/.gemini
@@ -21,15 +21,9 @@ This file contains useful findings, domain knowledge, and development instructio
 - Tuesday Team 2 is the **`Subs`** team (with roster players Sawyer Kuck, Dave Mills, etc.). 
 - When rosters are regenerated, ensure it is named `Subs` rather than defaulting to `BYE`.
 
-### 3. Logan Alternate Location
-- When Green Island `Courts 1–5` are unavailable at `5:30pm` due to early-season conflicts, the affected matches are moved to **`Logan`** courts.
-- Keep the match times at **5:30pm** (do not apply 6:00pm overrides).
-- Dates requiring the Logan override are:
-  - Tuesday Week 2 (`2026-06-02`)
-  - Tuesday Week 3 (`2026-06-09`)
-  - Wednesday Week 1 (`2026-05-27`)
-  - Wednesday Week 2 (`2026-06-03`)
-  - Wednesday Week 3 (`2026-06-10`)
+### 3. Logan Alternate Location (Retired)
+- Previously, matches were moved to **`Logan`** courts when Green Island `Courts 1–5` were unavailable at `5:30pm` due to early-season conflicts.
+- This override has been completely removed in May 2026. All matches now show they are at Green Island (using standard court groups like `Courts 1–5`).
 
 ---
 

--- a/management-scripts/create-emails.js
+++ b/management-scripts/create-emails.js
@@ -84,7 +84,7 @@ function generateEmailTemplate(team) {
 
             <h2>The Basics</h2>
             <ul>
-                <li><strong>When & Where:</strong> Matches are played on ${escapeHTML(matchDay)} evenings at Green Island Park. Start times rotate between 5:30 pm and 7:00 pm. <strong>Please pay attention to the schedule location, as a few matches are at Logan due to court conflicts.</strong></li>
+                <li><strong>When & Where:</strong> Matches are played on ${escapeHTML(matchDay)} evenings at Green Island Park. Start times rotate between 5:30 pm and 7:00 pm. <strong>Please pay attention to the schedule location.</strong></li>
                 <li><strong>Punctuality:</strong> Please arrive 10 minutes prior to your scheduled match time. The 15-minute forfeit rule is strictly in effect.</li>
                 <li><strong>League Website:</strong> Find schedules, standings, and sub lists at <a href="https://couleeregiontennis.org">couleeregiontennis.org</a></li>
                 <li><strong>Subs:</strong> If you can't make a match, you are responsible for finding a sub. Check the <a href="https://couleeregiontennis.org/pages/subs.html">Sub List and GroupMe links</a> on the website.</li>

--- a/management-scripts/generate-rr.js
+++ b/management-scripts/generate-rr.js
@@ -333,11 +333,7 @@ async function main() {
       weekAssignments.forEach((matches, weekIdx) => {
         const dateStr = weekDates[weekIdx];
         matches.forEach(match => {
-          // Date specific overrides
-          if (['2026-05-27', '2026-06-02', '2026-06-03', '2026-06-09', '2026-06-10'].includes(dateStr) && match.time === '5:30pm') {
-            if (match.court === 'Courts 1–5') {
-              match.court = 'Logan';
-            }
+
           }
 
           // Find team objects for A and B

--- a/management-scripts/ltta-apps-script.js
+++ b/management-scripts/ltta-apps-script.js
@@ -142,7 +142,7 @@ function generateEmailHtml(team) {
 
         '<h2 style="color: #2e7d32; border-bottom: 1px solid #eeeeee; padding-bottom: 5px; margin-top: 30px;">The Basics</h2>' +
         '<ul style="padding-left: 20px;">' +
-          '<li style="margin-bottom: 10px;"><strong>When & Where:</strong> Matches are played on ' + matchDay + ' evenings at Green Island Park. Start times rotate between 5:30 pm and 7:00 pm. <strong>Please pay attention to the schedule location, as a few matches are at Logan due to court conflicts.</strong></li>' +
+          '<li style="margin-bottom: 10px;"><strong>When & Where:</strong> Matches are played on ' + matchDay + ' evenings at Green Island Park. Start times rotate between 5:30 pm and 7:00 pm. <strong>Please pay attention to the schedule location.</strong></li>' +
           '<li style="margin-bottom: 10px;"><strong>Punctuality:</strong> Please arrive 10 minutes prior to your scheduled match time.</li>' +
           '<li style="margin-bottom: 10px;"><strong>League Website:</strong> <a href="https://couleeregiontennis.org" style="color: #2e7d32; font-weight: bold;">couleeregiontennis.org</a></li>' +
         '</ul>' +

--- a/pages/greenisland.html
+++ b/pages/greenisland.html
@@ -27,8 +27,7 @@
         </a>
         and are a popular destination for tennis enthusiasts in the area. The facility features multiple courts that are well-maintained and open to the public. These courts are used for recreational play, league matches, and tournaments.
       </p>
-      <p>When we have conflicts with Green Island court times we often make use of courts nearby, usually Logan Tennis Courts.
-      </p>    </section>
+          </section>
 
     <section class="court-numbering">
       <h2>Court Numbering</h2>

--- a/pages/ltta-rules.html
+++ b/pages/ltta-rules.html
@@ -51,9 +51,7 @@
           point (lost only for forfeits).</li>
         <li><strong>Heat Rule:</strong> Now uses the "RealFeel" temperature from accuweather.com (95°F optional start;
           104°F cancellation).</li>
-        <li><strong>Alternate Location:</strong> Logan will serve as the backup site when Green Island is in use
-          by Aquinas or UWL.</li>
-        <li><strong>Committee Elections:</strong> All committee positions are now biennial and will use a digital
+<li><strong>Committee Elections:</strong> All committee positions are now biennial and will use a digital
           nomination/voting process.</li>
         <li><strong>Lineup Transparency:</strong> Home teams must complete their lineup sheet first if there is a
           dispute over the #3 line. In the online schedules and calendar invites, the home team is identified by a
@@ -73,8 +71,7 @@
         </li>
         <li>
           Primary match location: <strong>Green Island Park</strong>, 2300 7th St
-          South, La Crosse, WI. In the event that Green Island courts are in use by Aquinas or UWL, matches will be
-          moved to <strong>Logan</strong>.
+          South, La Crosse, WI.
         </li>
         <li>
           Matches are scheduled for Tuesday and Wednesday evenings from June 3

--- a/teams/tuesday/all.html
+++ b/teams/tuesday/all.html
@@ -162,7 +162,7 @@
       <tr class="date-row"><td colspan="3">2-Jun</td></tr>
       <tr class="court-row">
         <td class="court-header">Courts 1–5</td>
-        <td class="match-cell"><span class="team-num">7</span>Good Ol' Boys (h) vs <span class="team-num">4</span>Approach Shots<br><small style="color: #666; font-weight: bold;">(Logan)</small><br></td>
+        <td class="match-cell"><span class="team-num">7</span>Good Ol' Boys (h) vs <span class="team-num">4</span>Approach Shots<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
         <td class="match-cell"><span class="team-num">8</span>Return to Sender with Love (h) vs <span class="team-num">3</span>Herons<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
       <tr class="court-row">
@@ -178,7 +178,7 @@
       <tr class="date-row"><td colspan="3">9-Jun</td></tr>
       <tr class="court-row">
         <td class="court-header">Courts 1–5</td>
-        <td class="match-cell"><span class="team-num">10</span>Jetsetters (h) vs <span class="team-num">1</span>Spin Doctors<br><small style="color: #666; font-weight: bold;">(Logan)</small><br></td>
+        <td class="match-cell"><span class="team-num">10</span>Jetsetters (h) vs <span class="team-num">1</span>Spin Doctors<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
         <td class="match-cell"><span class="team-num">4</span>Approach Shots (h) vs <span class="team-num">5</span>Racquet Scientists<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
       <tr class="court-row">

--- a/teams/tuesday/ics/1/team.ics
+++ b/teams/tuesday/ics/1/team.ics
@@ -35,8 +35,8 @@ DTSTAMP:20260609T173000Z
 DTSTART;TZID=America/Chicago:20260609T173000
 DTEND;TZID=America/Chicago:20260609T190000
 SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 1 vs Jetsetters at Logan Tennis Courts\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 1 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/1/week3.ics
+++ b/teams/tuesday/ics/1/week3.ics
@@ -25,8 +25,8 @@ DTSTAMP:20260609T173000Z
 DTSTART;TZID=America/Chicago:20260609T173000
 DTEND;TZID=America/Chicago:20260609T190000
 SUMMARY:LTTA Tennis: vs Jetsetters (Away)
-DESCRIPTION:LTTA Tennis match: 1 vs Jetsetters at Logan Tennis Courts\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 1 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/10/team.ics
+++ b/teams/tuesday/ics/10/team.ics
@@ -35,8 +35,8 @@ DTSTAMP:20260609T173000Z
 DTSTART;TZID=America/Chicago:20260609T173000
 DTEND;TZID=America/Chicago:20260609T190000
 SUMMARY:LTTA Tennis: vs Spin Doctors
-DESCRIPTION:LTTA Tennis match: 10 vs Spin Doctors at Logan Tennis Courts\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 10 vs Spin Doctors at Green Island Park - Courts 1–5\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/10/week3.ics
+++ b/teams/tuesday/ics/10/week3.ics
@@ -25,8 +25,8 @@ DTSTAMP:20260609T173000Z
 DTSTART;TZID=America/Chicago:20260609T173000
 DTEND;TZID=America/Chicago:20260609T190000
 SUMMARY:LTTA Tennis: vs Spin Doctors (Home)
-DESCRIPTION:LTTA Tennis match: 10 vs Spin Doctors at Logan Tennis Courts\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 10 vs Spin Doctors at Green Island Park - Courts 1–5\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/4/team.ics
+++ b/teams/tuesday/ics/4/team.ics
@@ -21,8 +21,8 @@ DTSTAMP:20260602T173000Z
 DTSTART;TZID=America/Chicago:20260602T173000
 DTEND;TZID=America/Chicago:20260602T190000
 SUMMARY:LTTA Tennis: vs Good Ol' Boys
-DESCRIPTION:LTTA Tennis match: 4 vs Good Ol' Boys at Logan Tennis Courts\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 4 vs Good Ol' Boys at Green Island Park - Courts 1–5\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/4/week2.ics
+++ b/teams/tuesday/ics/4/week2.ics
@@ -25,8 +25,8 @@ DTSTAMP:20260602T173000Z
 DTSTART;TZID=America/Chicago:20260602T173000
 DTEND;TZID=America/Chicago:20260602T190000
 SUMMARY:LTTA Tennis: vs Good Ol' Boys (Away)
-DESCRIPTION:LTTA Tennis match: 4 vs Good Ol' Boys at Logan Tennis Courts\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 4 vs Good Ol' Boys at Green Island Park - Courts 1–5\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/7/team.ics
+++ b/teams/tuesday/ics/7/team.ics
@@ -21,8 +21,8 @@ DTSTAMP:20260602T173000Z
 DTSTART;TZID=America/Chicago:20260602T173000
 DTEND;TZID=America/Chicago:20260602T190000
 SUMMARY:LTTA Tennis: vs Approach Shots
-DESCRIPTION:LTTA Tennis match: 7 vs Approach Shots at Logan Tennis Courts\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 7 vs Approach Shots at Green Island Park - Courts 1–5\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/7/week2.ics
+++ b/teams/tuesday/ics/7/week2.ics
@@ -25,8 +25,8 @@ DTSTAMP:20260602T173000Z
 DTSTART;TZID=America/Chicago:20260602T173000
 DTEND;TZID=America/Chicago:20260602T190000
 SUMMARY:LTTA Tennis: vs Approach Shots (Home)
-DESCRIPTION:LTTA Tennis match: 7 vs Approach Shots at Logan Tennis Courts\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 7 vs Approach Shots at Green Island Park - Courts 1–5\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/schedules/1.json
+++ b/teams/tuesday/schedules/1.json
@@ -32,7 +32,7 @@
       "week": 3,
       "date": "2026-06-09",
       "time": "5:30pm",
-      "courts": "Logan",
+      "courts": "Courts 1–5",
       "homeAway": "Away",
       "opponent": {
         "name": "Jetsetters",

--- a/teams/tuesday/schedules/10.json
+++ b/teams/tuesday/schedules/10.json
@@ -32,7 +32,7 @@
       "week": 3,
       "date": "2026-06-09",
       "time": "5:30pm",
-      "courts": "Logan",
+      "courts": "Courts 1–5",
       "homeAway": "Home",
       "opponent": {
         "name": "Spin Doctors",

--- a/teams/tuesday/schedules/4.json
+++ b/teams/tuesday/schedules/4.json
@@ -19,7 +19,7 @@
       "week": 2,
       "date": "2026-06-02",
       "time": "5:30pm",
-      "courts": "Logan",
+      "courts": "Courts 1–5",
       "homeAway": "Away",
       "opponent": {
         "name": "Good Ol' Boys",

--- a/teams/tuesday/schedules/7.json
+++ b/teams/tuesday/schedules/7.json
@@ -19,7 +19,7 @@
       "week": 2,
       "date": "2026-06-02",
       "time": "5:30pm",
-      "courts": "Logan",
+      "courts": "Courts 1–5",
       "homeAway": "Home",
       "opponent": {
         "name": "Approach Shots",

--- a/teams/tuesday/schedules/master_schedule.json
+++ b/teams/tuesday/schedules/master_schedule.json
@@ -143,7 +143,7 @@
     "week": 2,
     "date": "2026-06-02",
     "time": "5:30pm",
-    "courts": "Logan",
+    "courts": "Courts 1–5",
     "teamA": {
       "number": "7",
       "name": "Good Ol' Boys"
@@ -171,7 +171,7 @@
     "week": 3,
     "date": "2026-06-09",
     "time": "5:30pm",
-    "courts": "Logan",
+    "courts": "Courts 1–5",
     "teamA": {
       "number": "10",
       "name": "Jetsetters"

--- a/teams/wednesday/all.html
+++ b/teams/wednesday/all.html
@@ -146,7 +146,7 @@
       <tr class="date-row"><td colspan="3">27-May</td></tr>
       <tr class="court-row">
         <td class="court-header">Courts 1–5</td>
-        <td class="match-cell"><span class="team-num">1</span>LAX-Winona Fusion (h) vs <span class="team-num">12</span>Nothing But Net<br><small style="color: #666; font-weight: bold;">(Logan)</small><br></td>
+        <td class="match-cell"><span class="team-num">1</span>LAX-Winona Fusion (h) vs <span class="team-num">12</span>Nothing But Net<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
         <td class="match-cell"><span class="team-num">2</span>Rally Monkeys (h) vs <span class="team-num">11</span>Simply Smashing<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
       <tr class="court-row">
@@ -162,7 +162,7 @@
       <tr class="date-row"><td colspan="3">3-Jun</td></tr>
       <tr class="court-row">
         <td class="court-header">Courts 1–5</td>
-        <td class="match-cell"><span class="team-num">7</span>Serve Aces (h) vs <span class="team-num">4</span>Hot Shots<br><small style="color: #666; font-weight: bold;">(Logan)</small><br></td>
+        <td class="match-cell"><span class="team-num">7</span>Serve Aces (h) vs <span class="team-num">4</span>Hot Shots<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
         <td class="match-cell"><span class="team-num">8</span>Not My Fault (h) vs <span class="team-num">3</span>Hit Squad<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
       <tr class="court-row">
@@ -178,7 +178,7 @@
       <tr class="date-row"><td colspan="3">10-Jun</td></tr>
       <tr class="court-row">
         <td class="court-header">Courts 1–5</td>
-        <td class="match-cell"><span class="team-num">10</span>Backhand Bandits (h) vs <span class="team-num">1</span>LAX-Winona Fusion<br><small style="color: #666; font-weight: bold;">(Logan)</small><br></td>
+        <td class="match-cell"><span class="team-num">10</span>Backhand Bandits (h) vs <span class="team-num">1</span>LAX-Winona Fusion<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
         <td class="match-cell"><span class="team-num">4</span>Hot Shots (h) vs <span class="team-num">5</span>Glory Days<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
       <tr class="court-row">

--- a/teams/wednesday/ics/1/team.ics
+++ b/teams/wednesday/ics/1/team.ics
@@ -7,8 +7,8 @@ DTSTAMP:20260527T173000Z
 DTSTART;TZID=America/Chicago:20260527T173000
 DTEND;TZID=America/Chicago:20260527T190000
 SUMMARY:LTTA Tennis: vs Nothing But Net
-DESCRIPTION:LTTA Tennis match: 1 vs Nothing But Net at Logan Tennis Courts\nOpponent Roster: Alex Hiller (1); Eric Johnson (2); Lewis Kuhlman (3); Sarah Wengerter (3); Brittney DeChambeau (3); Kevin LeQue (3); Asa Harter (4); Logan Bahr (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 1 vs Nothing But Net at Green Island Park - Courts 1–5\nOpponent Roster: Alex Hiller (1); Eric Johnson (2); Lewis Kuhlman (3); Sarah Wengerter (3); Brittney DeChambeau (3); Kevin LeQue (3); Asa Harter (4); Logan Bahr (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY
@@ -35,8 +35,8 @@ DTSTAMP:20260610T173000Z
 DTSTART;TZID=America/Chicago:20260610T173000
 DTEND;TZID=America/Chicago:20260610T190000
 SUMMARY:LTTA Tennis: vs Backhand Bandits
-DESCRIPTION:LTTA Tennis match: 1 vs Backhand Bandits at Logan Tennis Courts\nOpponent Roster: Leah Fortun (1); Josh Fortun (2); Jennifer Carr (3); Amy Marcou (3); Michael Ojelabi (3); Marc Crosby (3); Eli De Leon (4); Irene Johnson-Salvador (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 1 vs Backhand Bandits at Green Island Park - Courts 1–5\nOpponent Roster: Leah Fortun (1); Josh Fortun (2); Jennifer Carr (3); Amy Marcou (3); Michael Ojelabi (3); Marc Crosby (3); Eli De Leon (4); Irene Johnson-Salvador (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/wednesday/ics/1/week1.ics
+++ b/teams/wednesday/ics/1/week1.ics
@@ -25,8 +25,8 @@ DTSTAMP:20260527T173000Z
 DTSTART;TZID=America/Chicago:20260527T173000
 DTEND;TZID=America/Chicago:20260527T190000
 SUMMARY:LTTA Tennis: vs Nothing But Net (Home)
-DESCRIPTION:LTTA Tennis match: 1 vs Nothing But Net at Logan Tennis Courts\nOpponent Roster: Alex Hiller (1); Eric Johnson (2); Lewis Kuhlman (3); Sarah Wengerter (3); Brittney DeChambeau (3); Kevin LeQue (3); Asa Harter (4); Logan Bahr (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 1 vs Nothing But Net at Green Island Park - Courts 1–5\nOpponent Roster: Alex Hiller (1); Eric Johnson (2); Lewis Kuhlman (3); Sarah Wengerter (3); Brittney DeChambeau (3); Kevin LeQue (3); Asa Harter (4); Logan Bahr (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/wednesday/ics/1/week3.ics
+++ b/teams/wednesday/ics/1/week3.ics
@@ -25,8 +25,8 @@ DTSTAMP:20260610T173000Z
 DTSTART;TZID=America/Chicago:20260610T173000
 DTEND;TZID=America/Chicago:20260610T190000
 SUMMARY:LTTA Tennis: vs Backhand Bandits (Away)
-DESCRIPTION:LTTA Tennis match: 1 vs Backhand Bandits at Logan Tennis Courts\nOpponent Roster: Leah Fortun (1); Josh Fortun (2); Jennifer Carr (3); Amy Marcou (3); Michael Ojelabi (3); Marc Crosby (3); Eli De Leon (4); Irene Johnson-Salvador (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 1 vs Backhand Bandits at Green Island Park - Courts 1–5\nOpponent Roster: Leah Fortun (1); Josh Fortun (2); Jennifer Carr (3); Amy Marcou (3); Michael Ojelabi (3); Marc Crosby (3); Eli De Leon (4); Irene Johnson-Salvador (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/wednesday/ics/10/team.ics
+++ b/teams/wednesday/ics/10/team.ics
@@ -35,8 +35,8 @@ DTSTAMP:20260610T173000Z
 DTSTART;TZID=America/Chicago:20260610T173000
 DTEND;TZID=America/Chicago:20260610T190000
 SUMMARY:LTTA Tennis: vs LAX-Winona Fusion
-DESCRIPTION:LTTA Tennis match: 10 vs LAX-Winona Fusion at Logan Tennis Courts\nOpponent Roster: Pheng Lo (1); Dan Lewis (2); Joe Heer (3); Janice Hoeschler (3); Jeffrey Schott (3); Nikki Nakano (3); Lora Cadwell (4); Barb Buswell (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 10 vs LAX-Winona Fusion at Green Island Park - Courts 1–5\nOpponent Roster: Pheng Lo (1); Dan Lewis (2); Joe Heer (3); Janice Hoeschler (3); Jeffrey Schott (3); Nikki Nakano (3); Lora Cadwell (4); Barb Buswell (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/wednesday/ics/10/week3.ics
+++ b/teams/wednesday/ics/10/week3.ics
@@ -25,8 +25,8 @@ DTSTAMP:20260610T173000Z
 DTSTART;TZID=America/Chicago:20260610T173000
 DTEND;TZID=America/Chicago:20260610T190000
 SUMMARY:LTTA Tennis: vs LAX-Winona Fusion (Home)
-DESCRIPTION:LTTA Tennis match: 10 vs LAX-Winona Fusion at Logan Tennis Courts\nOpponent Roster: Pheng Lo (1); Dan Lewis (2); Joe Heer (3); Janice Hoeschler (3); Jeffrey Schott (3); Nikki Nakano (3); Lora Cadwell (4); Barb Buswell (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 10 vs LAX-Winona Fusion at Green Island Park - Courts 1–5\nOpponent Roster: Pheng Lo (1); Dan Lewis (2); Joe Heer (3); Janice Hoeschler (3); Jeffrey Schott (3); Nikki Nakano (3); Lora Cadwell (4); Barb Buswell (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/wednesday/ics/12/team.ics
+++ b/teams/wednesday/ics/12/team.ics
@@ -7,8 +7,8 @@ DTSTAMP:20260527T173000Z
 DTSTART;TZID=America/Chicago:20260527T173000
 DTEND;TZID=America/Chicago:20260527T190000
 SUMMARY:LTTA Tennis: vs LAX-Winona Fusion
-DESCRIPTION:LTTA Tennis match: 12 vs LAX-Winona Fusion at Logan Tennis Courts\nOpponent Roster: Pheng Lo (1); Dan Lewis (2); Joe Heer (3); Janice Hoeschler (3); Jeffrey Schott (3); Nikki Nakano (3); Lora Cadwell (4); Barb Buswell (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 12 vs LAX-Winona Fusion at Green Island Park - Courts 1–5\nOpponent Roster: Pheng Lo (1); Dan Lewis (2); Joe Heer (3); Janice Hoeschler (3); Jeffrey Schott (3); Nikki Nakano (3); Lora Cadwell (4); Barb Buswell (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/wednesday/ics/12/week1.ics
+++ b/teams/wednesday/ics/12/week1.ics
@@ -25,8 +25,8 @@ DTSTAMP:20260527T173000Z
 DTSTART;TZID=America/Chicago:20260527T173000
 DTEND;TZID=America/Chicago:20260527T190000
 SUMMARY:LTTA Tennis: vs LAX-Winona Fusion (Away)
-DESCRIPTION:LTTA Tennis match: 12 vs LAX-Winona Fusion at Logan Tennis Courts\nOpponent Roster: Pheng Lo (1); Dan Lewis (2); Joe Heer (3); Janice Hoeschler (3); Jeffrey Schott (3); Nikki Nakano (3); Lora Cadwell (4); Barb Buswell (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 12 vs LAX-Winona Fusion at Green Island Park - Courts 1–5\nOpponent Roster: Pheng Lo (1); Dan Lewis (2); Joe Heer (3); Janice Hoeschler (3); Jeffrey Schott (3); Nikki Nakano (3); Lora Cadwell (4); Barb Buswell (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/wednesday/ics/4/team.ics
+++ b/teams/wednesday/ics/4/team.ics
@@ -21,8 +21,8 @@ DTSTAMP:20260603T173000Z
 DTSTART;TZID=America/Chicago:20260603T173000
 DTEND;TZID=America/Chicago:20260603T190000
 SUMMARY:LTTA Tennis: vs Serve Aces
-DESCRIPTION:LTTA Tennis match: 4 vs Serve Aces at Logan Tennis Courts\nOpponent Roster: Mark Hoff (1); Randy Moseng (2); Luke/ Emily Bussiere (3); Franklin Greene (3); Nicole Hoff (3); Michelle Rank (3); Sharon Harter (4); Gary Harter (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 4 vs Serve Aces at Green Island Park - Courts 1–5\nOpponent Roster: Mark Hoff (1); Randy Moseng (2); Luke/ Emily Bussiere (3); Franklin Greene (3); Nicole Hoff (3); Michelle Rank (3); Sharon Harter (4); Gary Harter (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/wednesday/ics/4/week2.ics
+++ b/teams/wednesday/ics/4/week2.ics
@@ -25,8 +25,8 @@ DTSTAMP:20260603T173000Z
 DTSTART;TZID=America/Chicago:20260603T173000
 DTEND;TZID=America/Chicago:20260603T190000
 SUMMARY:LTTA Tennis: vs Serve Aces (Away)
-DESCRIPTION:LTTA Tennis match: 4 vs Serve Aces at Logan Tennis Courts\nOpponent Roster: Mark Hoff (1); Randy Moseng (2); Luke/ Emily Bussiere (3); Franklin Greene (3); Nicole Hoff (3); Michelle Rank (3); Sharon Harter (4); Gary Harter (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 4 vs Serve Aces at Green Island Park - Courts 1–5\nOpponent Roster: Mark Hoff (1); Randy Moseng (2); Luke/ Emily Bussiere (3); Franklin Greene (3); Nicole Hoff (3); Michelle Rank (3); Sharon Harter (4); Gary Harter (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/wednesday/ics/7/team.ics
+++ b/teams/wednesday/ics/7/team.ics
@@ -21,8 +21,8 @@ DTSTAMP:20260603T173000Z
 DTSTART;TZID=America/Chicago:20260603T173000
 DTEND;TZID=America/Chicago:20260603T190000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 7 vs Hot Shots at Logan Tennis Courts\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 7 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/wednesday/ics/7/week2.ics
+++ b/teams/wednesday/ics/7/week2.ics
@@ -25,8 +25,8 @@ DTSTAMP:20260603T173000Z
 DTSTART;TZID=America/Chicago:20260603T173000
 DTEND;TZID=America/Chicago:20260603T190000
 SUMMARY:LTTA Tennis: vs Hot Shots (Home)
-DESCRIPTION:LTTA Tennis match: 7 vs Hot Shots at Logan Tennis Courts\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
-LOCATION:Logan Tennis Courts
+DESCRIPTION:LTTA Tennis match: 7 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/wednesday/schedules/1.json
+++ b/teams/wednesday/schedules/1.json
@@ -6,7 +6,7 @@
       "week": 1,
       "date": "2026-05-27",
       "time": "5:30pm",
-      "courts": "Logan",
+      "courts": "Courts 1–5",
       "homeAway": "Home",
       "opponent": {
         "name": "Nothing But Net",
@@ -32,7 +32,7 @@
       "week": 3,
       "date": "2026-06-10",
       "time": "5:30pm",
-      "courts": "Logan",
+      "courts": "Courts 1–5",
       "homeAway": "Away",
       "opponent": {
         "name": "Backhand Bandits",

--- a/teams/wednesday/schedules/10.json
+++ b/teams/wednesday/schedules/10.json
@@ -32,7 +32,7 @@
       "week": 3,
       "date": "2026-06-10",
       "time": "5:30pm",
-      "courts": "Logan",
+      "courts": "Courts 1–5",
       "homeAway": "Home",
       "opponent": {
         "name": "LAX-Winona Fusion",

--- a/teams/wednesday/schedules/12.json
+++ b/teams/wednesday/schedules/12.json
@@ -6,7 +6,7 @@
       "week": 1,
       "date": "2026-05-27",
       "time": "5:30pm",
-      "courts": "Logan",
+      "courts": "Courts 1–5",
       "homeAway": "Away",
       "opponent": {
         "name": "LAX-Winona Fusion",

--- a/teams/wednesday/schedules/4.json
+++ b/teams/wednesday/schedules/4.json
@@ -19,7 +19,7 @@
       "week": 2,
       "date": "2026-06-03",
       "time": "5:30pm",
-      "courts": "Logan",
+      "courts": "Courts 1–5",
       "homeAway": "Away",
       "opponent": {
         "name": "Serve Aces",

--- a/teams/wednesday/schedules/7.json
+++ b/teams/wednesday/schedules/7.json
@@ -19,7 +19,7 @@
       "week": 2,
       "date": "2026-06-03",
       "time": "5:30pm",
-      "courts": "Logan",
+      "courts": "Courts 1–5",
       "homeAway": "Home",
       "opponent": {
         "name": "Hot Shots",

--- a/teams/wednesday/schedules/master_schedule.json
+++ b/teams/wednesday/schedules/master_schedule.json
@@ -3,7 +3,7 @@
     "week": 1,
     "date": "2026-05-27",
     "time": "5:30pm",
-    "courts": "Logan",
+    "courts": "Courts 1–5",
     "teamA": {
       "number": "1",
       "name": "LAX-Winona Fusion"
@@ -143,7 +143,7 @@
     "week": 2,
     "date": "2026-06-03",
     "time": "5:30pm",
-    "courts": "Logan",
+    "courts": "Courts 1–5",
     "teamA": {
       "number": "7",
       "name": "Serve Aces"
@@ -171,7 +171,7 @@
     "week": 3,
     "date": "2026-06-10",
     "time": "5:30pm",
-    "courts": "Logan",
+    "courts": "Courts 1–5",
     "teamA": {
       "number": "10",
       "name": "Backhand Bandits"


### PR DESCRIPTION
This PR removes the Logan court override from the schedule generator since all matches are now played at Green Island Park, and regenerates all schedule JSONs, ICS calendars, onboarding emails, and scoresheet HTMLs.