### PR TITLE
Fix GitHub Actions Deployment Failures in fetch-fallback-weather

### DIFF
--- a/scripts/fetch-fallback-weather.js
+++ b/scripts/fetch-fallback-weather.js
@@ -38,8 +38,8 @@ async function main() {
     fs.writeFileSync(outputPath, JSON.stringify(outputData, null, 2));
     console.log(`Weather fallback successfully written to ${outputPath}`);
   } catch (error) {
-    console.error('Error fetching fallback weather:', error);
-    process.exit(1);
+    console.warn('Warning: Failed to fetch fallback weather. Using the existing committed assets/weather-fallback.json instead.', error);
+    process.exit(0);
   }
 }
 


### PR DESCRIPTION
Modified `scripts/fetch-fallback-weather.js` to handle Open-Meteo API failures gracefully. Instead of calling `process.exit(1)` and failing the entire workflow during network outages, it now catches the error, logs a warning, and calls `process.exit(0)`. This allows the rest of the GitHub Actions pipeline to continue working and fallback onto the existing committed `assets/weather-fallback.json` file. All test cases run successfully.

---
*PR created automatically by Jules for task [9344900421341456179](https://jules.google.com/task/9344900421341456179) started by @BLMeddaugh*