### PR TITLE
feat: notify users of rain cancellation for tonight (June 17)

### DIFF
--- a/management-scripts/create-emails.js
+++ b/management-scripts/create-emails.js
@@ -101,7 +101,7 @@ function generateEmailTemplate(team) {
 
             <h2>Weather Cancellations / Rainouts</h2>
             <p>If play is officially canceled by the league due to weather, no match results are recorded. While players are welcome to use the courts for practice hits at their own discretion, any sets played will be completely unofficial and will not count toward league standings.</p>
-            <p>In the event of a partial cancellation &mdash; for example, if 5:30 PM matches are completed but 7:00 PM matches must be canceled due to deteriorating conditions &mdash; only the completed matches will count. Canceled matches will not be recorded, and standings will reflect a prorated format based on the percentage of possible points earned from matches actually played, ensuring teams are ranked fairly regardless of how many matches they were able to complete.</p>
+            <p>If only some time slots are affected &mdash; for example, 5:30 PM matches are completed but 7:00 PM matches are canceled &mdash; only the completed matches will count. Standings will be based on the percentage of possible points earned from matches played.</p>
 
             <h2>League Dues</h2>
             <p>Dues are <strong>$25 for the season</strong>, due by the 2nd week of play. Please pay your captain who will pass it on to a Coordinator.</p>

--- a/management-scripts/create-emails.js
+++ b/management-scripts/create-emails.js
@@ -99,6 +99,10 @@ function generateEmailTemplate(team) {
                 </ul>
             </div>
 
+            <h2>Weather Cancellations / Rainouts</h2>
+            <p>If play is officially canceled by the league due to weather, no match results are recorded. While players are welcome to use the courts for practice hits at their own discretion, any sets played will be completely unofficial and will not count toward league standings.</p>
+            <p>In the event of a partial cancellation &mdash; for example, if 5:30 PM matches are completed but 7:00 PM matches must be canceled due to deteriorating conditions &mdash; only the completed matches will count. Canceled matches will not be recorded, and standings will reflect a prorated format based on the percentage of possible points earned from matches actually played, ensuring teams are ranked fairly regardless of how many matches they were able to complete.</p>
+
             <h2>League Dues</h2>
             <p>Dues are <strong>$25 for the season</strong>, due by the 2nd week of play. Please pay your captain who will pass it on to a Coordinator.</p>
 

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -1,5 +1,11 @@
 <link rel="stylesheet" href="../styles/nav.css?v=2026.5" />
 <header>
+  <div class="announcement-banner">
+    <div class="announcement-content">
+      <span class="announcement-badge">Cancellation</span>
+      <span class="announcement-text">🌧️ All matches tonight (Wednesday, June 17) are cancelled due to rain.</span>
+    </div>
+  </div>
   <nav class="navbar">
     <div class="navbar-container">
       <div class="navbar-brand">

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -97,7 +97,13 @@ async function loadWeather(nextMatchDate) {
     let heatRuleClass = 'heat-alert-normal';
     const isRainy = (code >= 51 && code <= 67) || (code >= 80 && code <= 82) || (code >= 95 && code <= 99);
 
-    if (typeof apparentTemp === 'number') {
+    // Official rain cancellation override for tonight (Wednesday, June 17, 2026)
+    const isTonightCancelled = nextMatchDate === '2026-06-17';
+
+    if (isTonightCancelled) {
+      heatRuleText = '🌧️ Matches Cancelled Tonight (Rain)';
+      heatRuleClass = 'heat-alert-cancel';
+    } else if (typeof apparentTemp === 'number') {
       if (apparentTemp >= 104) {
         heatRuleText = '⚠️ OVER 104°F: Automatic Cancel!';
         heatRuleClass = 'heat-alert-cancel';
@@ -223,6 +229,7 @@ async function loadDashboard() {
 
     dates.forEach(date => {
       const isToday = date === todayStr;
+      const isCancelledDate = date === '2026-06-17';
       const dateObj = new Date(date + 'T12:00:00');
       const dayName = dateObj.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
       
@@ -262,10 +269,17 @@ async function loadDashboard() {
         </div>
       `).join('');
 
+      const cancellationNotice = isCancelledDate ? `
+        <div class="card-cancellation-notice" style="background: rgba(220, 53, 69, 0.12); color: #dc3545; font-weight: bold; text-align: center; padding: 6px; border-radius: 6px; font-size: 0.85rem; margin-bottom: 10px; border: 1px solid rgba(220, 53, 69, 0.25);">
+          🌧️ Canceled due to Rain
+        </div>
+      ` : '';
+
       html += `
-        <div class="day-card ${isToday ? 'today' : ''}">
+        <div class="day-card ${isToday ? 'today' : ''} ${isCancelledDate ? 'cancelled' : ''}">
           <h4 class="day-header">${isToday ? '🔥 TONIGHT' : dayName}</h4>
           <div class="day-slots-container">
+            ${cancellationNotice}
             ${renderedSlots || '<div class="no-matches">No matches scheduled</div>'}
           </div>
         </div>

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -46,10 +46,17 @@ async function loadTeamData(scheduleUrl, rosterUrl) {
     // Populate matches table
     tableBody.innerHTML = "";
     (scheduleData.schedule || []).forEach(match => {
+      const isCancelled = match.date === '2026-06-17';
       const icsLink = match.ics
         ? `<a href="${sanitizeUrl(match.ics)}?v=2026" download="LTTA-Match-Week${escapeHTML(match.week)}.ics" title="Add to calendar">📅</a>`
         : '';
       const tr = document.createElement("tr");
+      if (isCancelled) {
+        tr.classList.add("cancelled-match-row");
+      }
+      const courtContent = isCancelled 
+        ? `${escapeHTML(match.courts)} <span class="cancelled-badge">🌧️ Canceled</span>`
+        : escapeHTML(match.courts);
       tr.innerHTML = `
         <td>${escapeHTML(match.week)}</td>
         <td>${escapeHTML(formatDateUS(match.date))}</td>
@@ -58,7 +65,7 @@ async function loadTeamData(scheduleUrl, rosterUrl) {
         <td>
           <a href="${sanitizeUrl(match.opponent.file)}" class="team-link">${escapeHTML(match.opponent.name || "Team " + match.opponent.number)}</a>
         </td>
-        <td>${escapeHTML(match.courts)}</td>
+        <td>${courtContent}</td>
         <td style="text-align:center">${icsLink}</td>
       `;
       tableBody.appendChild(tr);

--- a/styles/nav.css
+++ b/styles/nav.css
@@ -285,3 +285,65 @@
   font-weight: bold;
   cursor: pointer;
 }
+
+/* Announcement Banner */
+.announcement-banner {
+  background: linear-gradient(135deg, #d32f2f, #c62828);
+  color: #ffffff;
+  padding: 8px 16px;
+  text-align: center;
+  font-size: 0.95rem;
+  font-weight: 600;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  animation: slideDown 0.4s ease-out;
+}
+
+[data-theme='dark'] .announcement-banner {
+  background: linear-gradient(135deg, #b71c1c, #880e4f);
+}
+
+.announcement-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.announcement-badge {
+  background-color: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: bold;
+  animation: pulse 2s infinite;
+}
+
+@keyframes slideDown {
+  from { transform: translateY(-100%); }
+  to { transform: translateY(0); }
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+@media (max-width: 600px) {
+  .announcement-banner {
+    font-size: 0.85rem;
+    padding: 6px 12px;
+  }
+  .announcement-badge {
+    font-size: 0.7rem;
+    padding: 1px 6px;
+  }
+}

--- a/styles/style.css
+++ b/styles/style.css
@@ -482,3 +482,65 @@ img {
   border: 1px solid var(--active-match-border);
   white-space: nowrap;
 }
+
+/* Cancelled day card styling */
+.day-card.cancelled {
+  border: 1.5px solid var(--border-color);
+  background: rgba(220, 53, 69, 0.05);
+  position: relative;
+}
+
+[data-theme='dark'] .day-card.cancelled {
+  background: rgba(220, 53, 69, 0.1);
+  border-color: rgba(220, 53, 69, 0.3);
+}
+
+.day-card.cancelled .day-header {
+  color: #dc3545;
+  border-bottom-color: rgba(220, 53, 69, 0.3);
+}
+
+[data-theme='dark'] .day-card.cancelled .day-header {
+  color: #e74c3c;
+}
+
+.day-card.cancelled .match-row {
+  opacity: 0.5;
+  text-decoration: line-through;
+}
+
+[data-theme='dark'] .day-card.cancelled .card-cancellation-notice {
+  color: #e74c3c !important;
+  border-color: rgba(231, 76, 60, 0.3) !important;
+  background: rgba(231, 76, 60, 0.1) !important;
+}
+
+/* Cancelled match rows in schedule tables */
+.cancelled-match-row {
+  text-decoration: line-through;
+  opacity: 0.6;
+  background-color: rgba(220, 53, 69, 0.04) !important;
+}
+
+[data-theme='dark'] .cancelled-match-row {
+  background-color: rgba(220, 53, 69, 0.08) !important;
+}
+
+.cancelled-badge {
+  color: #dc3545;
+  font-weight: bold;
+  font-size: 0.8rem;
+  margin-left: 6px;
+  background: rgba(220, 53, 69, 0.1);
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid rgba(220, 53, 69, 0.2);
+  white-space: nowrap;
+  display: inline-block;
+}
+
+[data-theme='dark'] .cancelled-badge {
+  color: #e74c3c;
+  background: rgba(231, 76, 60, 0.15);
+  border-color: rgba(231, 76, 60, 0.3);
+}

--- a/tests/email-template.test.js
+++ b/tests/email-template.test.js
@@ -29,6 +29,8 @@ test('generateEmailTemplate should return a string containing team details', (t)
   assert.ok(html.includes('RealFeel'), 'Should include heat rule');
   assert.ok(html.includes('crossover championship'), 'Should include championship details');
   assert.ok(html.includes('href="https://couleeregiontennis.org"'), 'Should include website domain');
+  assert.ok(html.includes('Weather Cancellations / Rainouts'), 'Should include weather cancellations heading');
+  assert.ok(html.includes('prorated format based on the percentage of possible points'), 'Should include partial cancellation/prorating details');
 });
 
 test('generateEmailTemplate should handle Wednesday teams', (t) => {

--- a/tests/email-template.test.js
+++ b/tests/email-template.test.js
@@ -30,7 +30,7 @@ test('generateEmailTemplate should return a string containing team details', (t)
   assert.ok(html.includes('crossover championship'), 'Should include championship details');
   assert.ok(html.includes('href="https://couleeregiontennis.org"'), 'Should include website domain');
   assert.ok(html.includes('Weather Cancellations / Rainouts'), 'Should include weather cancellations heading');
-  assert.ok(html.includes('prorated format based on the percentage of possible points'), 'Should include partial cancellation/prorating details');
+  assert.ok(html.includes('percentage of possible points earned from matches played'), 'Should include partial cancellation details');
 });
 
 test('generateEmailTemplate should handle Wednesday teams', (t) => {


### PR DESCRIPTION
This PR adds rain cancellation notifications to the website for tonight's matches (Wednesday, June 17, 2026):
1. **Global Banner**: Adds a prominent red cancellation alert banner at the top of the header in `nav.html` that shows up on all pages.
2. **Dashboard Schedule**: Highlights that tonight's matches are canceled with a card notice and strikes through the matches.
3. **Weather Widget**: Updates the weather rule display to officially report the rain cancellation tonight.
4. **Team Schedule Page**: Striking through the match row for June 17 and showing a `Canceled` badge in the courts column.