### PR TITLE
feat(tuesday): swap week 5 and week 10 schedule to resolve Subs team conflict

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
   <link rel="icon" href="assets/logo192.png" />
   <link rel="apple-touch-icon" href="assets/logo192.png" />
   <link rel="manifest" href="manifest.json" />
-  <link rel="stylesheet" href="styles/style.css?v=2026.6" />
-  <link rel="stylesheet" href="styles/nav.css?v=2026.6" />
+  <link rel="stylesheet" href="styles/style.css?v=2026.8" />
+  <link rel="stylesheet" href="styles/nav.css?v=2026.8" />
   <script src="https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js"></script>
 </head>
 
@@ -76,40 +76,40 @@
         <p>Choose your team to view your match schedule.</p>
         <ul class="team-list">
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=1">Team 1 – LAX-Winona Fusion</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=1">Team 1 – LAX-Winona Fusion</a>
           </li>
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=2">Team 2 – Rally Monkeys</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=2">Team 2 – Rally Monkeys</a>
           </li>
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=3">Team 3 – Hit Squad</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=3">Team 3 – Hit Squad</a>
           </li>
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=4">Team 4 – Hot Shots</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=4">Team 4 – Hot Shots</a>
           </li>
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=5">Team 5 – Glory Days</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=5">Team 5 – Glory Days</a>
           </li>
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=6">Team 6 – Howie's Team</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=6">Team 6 – Howie's Team</a>
           </li>
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=7">Team 7 – Serve Aces</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=7">Team 7 – Serve Aces</a>
           </li>
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=8">Team 8 – Not My Fault</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=8">Team 8 – Not My Fault</a>
           </li>
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=9">Team 9 – Baseliners</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=9">Team 9 – Baseliners</a>
           </li>
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=10">Team 10 – Backhand Bandits</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=10">Team 10 – Backhand Bandits</a>
           </li>
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=11">Team 11 – Simply Smashing</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=11">Team 11 – Simply Smashing</a>
           </li>
           <li>
-            <a href="pages/team.html?v=2026.6&day=wednesday&team=12">Team 12 – Nothing But Net</a>
+            <a href="pages/team.html?v=2026.8&day=wednesday&team=12">Team 12 – Nothing But Net</a>
           </li>
         </ul>
       </div>
@@ -117,9 +117,9 @@
   </main>
 
   <footer></footer>
-  <script src="scripts/nav.js?v=2026.6"></script>
-  <script src="scripts/team.js?v=2026.6"></script>
-  <script src="scripts/dashboard.js?v=2026.6"></script>
+  <script src="scripts/nav.js?v=2026.8"></script>
+  <script src="scripts/team.js?v=2026.8"></script>
+  <script src="scripts/dashboard.js?v=2026.8"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
             <a href="pages/team.html?day=tuesday&team=1">Team 1 – Spin Doctors</a>
           </li>
           <li>
-            <a href="pages/team.html?day=tuesday&team=2">Team 2 – BYE</a>
+            <a href="pages/team.html?day=tuesday&team=2">Team 2 – Subs</a>
           </li>
           <li>
             <a href="pages/team.html?day=tuesday&team=3">Team 3 – Herons</a>

--- a/management-scripts/bump-version.js
+++ b/management-scripts/bump-version.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Configuration
+const ROOT_DIR = path.resolve(__dirname, '..');
+const INDEX_HTML_PATH = path.join(ROOT_DIR, 'index.html');
+
+// Directories to scan and update
+const TARGET_PATHS = [
+  INDEX_HTML_PATH,
+  path.join(ROOT_DIR, 'pages'),
+  path.join(ROOT_DIR, 'partials'),
+  path.join(ROOT_DIR, 'scripts')
+];
+
+// Regex to match cache-buster query parameter (matches e.g. ?v=2026, ?v=2026.6, ?v=2026.12)
+// Restricts to 20XX years to avoid matching external URLs or youtube video parameters (e.g. ?v=dQw4w9WgXcQ)
+const VERSION_REGEX = /\?v=(20\d{2}(?:\.\d+)?)/g;
+
+function getFilesRecursively(dirOrFile, fileList = []) {
+  const stat = fs.statSync(dirOrFile);
+  if (stat.isFile()) {
+    const ext = path.extname(dirOrFile);
+    if (ext === '.html' || ext === '.js') {
+      fileList.push(dirOrFile);
+    }
+  } else if (stat.isDirectory()) {
+    const basename = path.basename(dirOrFile);
+    if (basename !== 'node_modules' && basename !== '.git' && basename !== 'management-scripts') {
+      const files = fs.readdirSync(dirOrFile);
+      for (const file of files) {
+        getFilesRecursively(path.join(dirOrFile, file), fileList);
+      }
+    }
+  }
+  return fileList;
+}
+
+function getStagedFiles() {
+  try {
+    const stdout = execSync('git diff --cached --name-only', { encoding: 'utf8', cwd: ROOT_DIR });
+    return stdout.split('\n').map(f => f.trim()).filter(Boolean);
+  } catch (err) {
+    console.error('Error checking staged files:', err.message);
+    return [];
+  }
+}
+
+function shouldTriggerBump(stagedFiles) {
+  const triggerPatterns = [
+    /^teams\//,
+    /^styles\//,
+    /^scripts\//,
+    /^pages\/.*\.html$/,
+    /^partials\/.*\.html$/,
+    /^index\.html$/
+  ];
+
+  return stagedFiles.some(file => {
+    // Normalize path separators
+    const normalized = file.replace(/\\/g, '/');
+    return triggerPatterns.some(pattern => pattern.test(normalized));
+  });
+}
+
+function getNewVersion(currentVersion) {
+  const parts = currentVersion.split('.');
+  if (parts.length === 1) {
+    return `${parts[0]}.1`;
+  }
+  const major = parts[0];
+  const minor = parseInt(parts[1], 10);
+  if (isNaN(minor)) {
+    return `${major}.1`;
+  }
+  return `${major}.${minor + 1}`;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const isGitHook = args.includes('--git-hook');
+
+  if (isGitHook) {
+    const stagedFiles = getStagedFiles();
+    if (!shouldTriggerBump(stagedFiles)) {
+      console.log('No relevant files staged for cache-busting. Skipping version bump.');
+      process.exit(0);
+    }
+  }
+
+  // 1. Read index.html to find current version
+  if (!fs.existsSync(INDEX_HTML_PATH)) {
+    console.error(`Error: index.html not found at ${INDEX_HTML_PATH}`);
+    process.exit(1);
+  }
+
+  const indexContent = fs.readFileSync(INDEX_HTML_PATH, 'utf8');
+  // Reset regex index
+  VERSION_REGEX.lastIndex = 0;
+  const match = VERSION_REGEX.exec(indexContent);
+  if (!match) {
+    console.error('Error: Could not find a version parameter matching "?v=20XX.X" or "?v=20XX" in index.html.');
+    process.exit(1);
+  }
+
+  const currentVersion = match[1];
+  let newVersion = '';
+
+  // Check if manual version was provided as argument
+  const manualVersionArg = args.find(arg => !arg.startsWith('--'));
+  if (manualVersionArg) {
+    if (!/^20\d{2}(?:\.\d+)?$/.test(manualVersionArg)) {
+      console.error(`Error: Invalid manual version "${manualVersionArg}". Must be in format 20XX or 20XX.X.`);
+      process.exit(1);
+    }
+    newVersion = manualVersionArg;
+  } else {
+    newVersion = getNewVersion(currentVersion);
+  }
+
+  if (currentVersion === newVersion) {
+    console.log(`Version is already at ${newVersion}. No changes needed.`);
+    process.exit(0);
+  }
+
+  console.log(`Bumping cache-busting version: ${currentVersion} -> ${newVersion}`);
+
+  // 2. Gather all files to update
+  const filesToUpdate = [];
+  for (const targetPath of TARGET_PATHS) {
+    if (fs.existsSync(targetPath)) {
+      getFilesRecursively(targetPath, filesToUpdate);
+    }
+  }
+
+  // Deduplicate files
+  const uniqueFiles = [...new Set(filesToUpdate)];
+  const updatedFiles = [];
+
+  // 3. Replace version in all files
+  for (const file of uniqueFiles) {
+    const content = fs.readFileSync(file, 'utf8');
+    VERSION_REGEX.lastIndex = 0;
+    if (VERSION_REGEX.test(content)) {
+      const updatedContent = content.replace(VERSION_REGEX, `?v=${newVersion}`);
+      fs.writeFileSync(file, updatedContent, 'utf8');
+      updatedFiles.push(file);
+    }
+  }
+
+  if (updatedFiles.length > 0) {
+    console.log(`Updated version in ${updatedFiles.length} files:`);
+    for (const file of updatedFiles) {
+      const relPath = path.relative(ROOT_DIR, file);
+      console.log(`  - ${relPath}`);
+      if (isGitHook) {
+        // Stage the updated file
+        try {
+          execSync(`git add "${file}"`, { cwd: ROOT_DIR });
+        } catch (addErr) {
+          console.error(`Failed to git add ${relPath}:`, addErr.message);
+        }
+      }
+    }
+  } else {
+    console.log('No version occurrences found to update.');
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/management-scripts/generate-rr.js
+++ b/management-scripts/generate-rr.js
@@ -288,11 +288,13 @@ async function main() {
 
       const rosterDir = path.join(OUTPUT_DIR, night, "rosters");
       const rosters = {};
+      const teamNames = {};
       if (fs.existsSync(rosterDir)) {
         fs.readdirSync(rosterDir).forEach(file => {
           const teamNum = file.replace(/\.json$/, '');
           const data = JSON.parse(fs.readFileSync(path.join(rosterDir, file)));
           rosters[teamNum] = data.roster || [];
+          teamNames[teamNum] = data.teamName;
         });
       }
 
@@ -311,6 +313,14 @@ async function main() {
       });
 
       const weekAssignments = assignSlotsToMatches(matchesByWeek, teams);
+
+      // NOTE: This swap is specific to the 2026 season to resolve a Tuesday night Subs team conflict. Remove or update this for future seasons.
+      if (night === 'tuesday') {
+        console.log("Swapping Week 5 and Week 10 schedules for Tuesday...");
+        const temp = weekAssignments[4];
+        weekAssignments[4] = weekAssignments[9];
+        weekAssignments[9] = temp;
+      }
 
       // Set start date based on night
       let startDate = START_DATE;
@@ -334,11 +344,11 @@ async function main() {
         const dateStr = weekDates[weekIdx];
         matches.forEach(match => {
 
-          }
-
           // Find team objects for A and B
           const teamA = teams.find(t => t.number === match.teamA.number);
           const teamB = teams.find(t => t.number === match.teamB.number);
+          const teamAName = teamNames[teamA.number] || teamA.name;
+          const teamBName = teamNames[teamB.number] || teamB.name;
           const entry = {
             week: weekIdx + 1,
             date: weekDates[weekIdx],
@@ -346,7 +356,7 @@ async function main() {
             courts: match.court,
             homeAway: "Home",
             opponent: {
-              name: teamB.name,
+              name: teamBName,
               number: teamB.number,
               file: `/pages/team.html?day=${night}&team=${teamB.number}`
             }
@@ -358,7 +368,7 @@ async function main() {
             courts: match.court,
             homeAway: "Away",
             opponent: {
-              name: teamA.name,
+              name: teamAName,
               number: teamA.number,
               file: `/pages/team.html?day=${night}&team=${teamA.number}`
             }
@@ -481,13 +491,21 @@ async function main() {
       const masterSchedule = [];
       weekAssignments.forEach((matches, weekIdx) => {
         matches.forEach(match => {
+          const nameA = teamNames[match.teamA.number] || match.teamA.name;
+          const nameB = teamNames[match.teamB.number] || match.teamB.name;
           masterSchedule.push({
             week: weekIdx + 1,
             date: weekDates[weekIdx],
             time: match.time,
             courts: match.court,
-            teamA: match.teamA,
-            teamB: match.teamB
+            teamA: {
+              number: match.teamA.number,
+              name: nameA
+            },
+            teamB: {
+              number: match.teamB.number,
+              name: nameB
+            }
           });
         });
       });

--- a/management-scripts/install-hook.js
+++ b/management-scripts/install-hook.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const GIT_DIR = path.join(ROOT_DIR, '.git');
+const HOOKS_DIR = path.join(GIT_DIR, 'hooks');
+const PRE_COMMIT_PATH = path.join(HOOKS_DIR, 'pre-commit');
+
+function main() {
+  if (!fs.existsSync(GIT_DIR)) {
+    console.log('No .git directory found. Skipping pre-commit hook installation.');
+    process.exit(0);
+  }
+
+  if (!fs.existsSync(HOOKS_DIR)) {
+    fs.mkdirSync(HOOKS_DIR, { recursive: true });
+  }
+
+  const hookContent = `#!/bin/sh
+# Automatically bump cache-busting version on relevant changes
+node management-scripts/bump-version.js --git-hook
+`;
+
+  fs.writeFileSync(PRE_COMMIT_PATH, hookContent, { encoding: 'utf8', mode: 0o755 });
+  console.log('Git pre-commit hook installed successfully.');
+
+  // Ensure executable permissions on Unix systems
+  if (process.platform !== 'win32') {
+    try {
+      execSync(`chmod +x "${PRE_COMMIT_PATH}"`);
+      console.log('Pre-commit hook marked as executable.');
+    } catch (err) {
+      console.warn('Warning: Could not make pre-commit hook executable via chmod:', err.message);
+    }
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "dotenv": "^17.4.2"
   },
   "scripts": {
+    "prepare": "node management-scripts/install-hook.js",
+    "bump-version": "node management-scripts/bump-version.js",
     "test": "npx playwright test",
     "test:unit": "node management-scripts/generate-scoresheet.js && node --test tests/email-template.test.js tests/schedule-alignment.test.js"
   }

--- a/pages/greenisland.html
+++ b/pages/greenisland.html
@@ -8,8 +8,8 @@
   <link rel="icon" href="../assets/logo192.png" />
   <link rel="apple-touch-icon" href="../assets/logo192.png" />
   <link rel="manifest" href="../manifest.json" />
-  <link rel="stylesheet" href="../styles/style.css?v=2026.6">
-  <link rel="stylesheet" href="../styles/nav.css?v=2026.6">
+  <link rel="stylesheet" href="../styles/style.css?v=2026.8">
+  <link rel="stylesheet" href="../styles/nav.css?v=2026.8">
 <script src="https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js"></script>
 </head><body>
   <div id="nav-placeholder"></div>
@@ -68,6 +68,6 @@
   <footer>
    </footer>
 
-  <script src="../scripts/nav.js?v=2026.6"></script>
+  <script src="../scripts/nav.js?v=2026.8"></script>
 </body>
 </html>

--- a/pages/ltta-rules.html
+++ b/pages/ltta-rules.html
@@ -8,14 +8,14 @@
   <link rel="icon" href="../assets/logo192.png" />
   <link rel="apple-touch-icon" href="../assets/logo192.png" />
   <link rel="manifest" href="../manifest.json" />
-  <link rel="stylesheet" href="../styles/nav.css?v=2026.6" />
-  <link rel="stylesheet" href="../styles/style.css?v=2026.6" />
-  <link rel="stylesheet" href="../styles/rules.css?v=2026.6" />
+  <link rel="stylesheet" href="../styles/nav.css?v=2026.8" />
+  <link rel="stylesheet" href="../styles/style.css?v=2026.8" />
+  <link rel="stylesheet" href="../styles/rules.css?v=2026.8" />
   <script src="https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js"></script>
 </head>
 
 <body>
-  <script src="../scripts/nav.js?v=2026.6"></script>
+  <script src="../scripts/nav.js?v=2026.8"></script>
   <div id="nav-placeholder"></div>
   <main>
     <h1>La Crosse Team Tennis Association (LTTA) – Summer League 2026</h1>

--- a/pages/standings.html
+++ b/pages/standings.html
@@ -7,8 +7,8 @@
     <link rel="icon" href="../assets/logo192.png" />
     <link rel="apple-touch-icon" href="../assets/logo192.png" />
     <link rel="manifest" href="../manifest.json" />
-    <link rel="stylesheet" href="../styles/style.css?v=2026.6" />
-    <link rel="stylesheet" href="../styles/nav.css?v=2026.6" />
+    <link rel="stylesheet" href="../styles/style.css?v=2026.8" />
+    <link rel="stylesheet" href="../styles/nav.css?v=2026.8" />
     <link rel="stylesheet" href="../styles/standings.css" />
     <script src="https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js"></script>
     <style>
@@ -42,8 +42,8 @@
         </table>
       </div>
     </main>
-    <script src="../scripts/nav.js?v=2026.6"></script>
-    <script src="../scripts/standings.js?v=2026.6"></script>
+    <script src="../scripts/nav.js?v=2026.8"></script>
+    <script src="../scripts/standings.js?v=2026.8"></script>
   </body>
 </html>
 

--- a/pages/subs.html
+++ b/pages/subs.html
@@ -7,13 +7,13 @@
     <link rel="icon" href="../assets/logo192.png" />
     <link rel="apple-touch-icon" href="../assets/logo192.png" />
     <link rel="manifest" href="../manifest.json" />
-    <link rel="stylesheet" href="../styles/nav.css?v=2026.6" />
-    <link rel="stylesheet" href="../styles/style.css?v=2026.6" />
-    <link rel="stylesheet" href="../styles/subs.css?v=2026.6" />
+    <link rel="stylesheet" href="../styles/nav.css?v=2026.8" />
+    <link rel="stylesheet" href="../styles/style.css?v=2026.8" />
+    <link rel="stylesheet" href="../styles/subs.css?v=2026.8" />
     <script src="https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js"></script>
   </head>
   <body>
-    <script src="../scripts/nav.js?v=2026.6"></script>
+    <script src="../scripts/nav.js?v=2026.8"></script>
     <div id="nav-placeholder"></div>
     <main>
       <h1>LTTA Sub GroupMe Links</h1>

--- a/pages/team.html
+++ b/pages/team.html
@@ -6,8 +6,8 @@
   <link rel="icon" href="../assets/logo192.png" />
   <link rel="apple-touch-icon" href="../assets/logo192.png" />
   <link rel="manifest" href="../manifest.json" />
-  <link rel="stylesheet" href="../styles/style.css?v=2026.6">
-  <link rel="stylesheet" href="../styles/nav.css?v=2026.6">
+  <link rel="stylesheet" href="../styles/style.css?v=2026.8">
+  <link rel="stylesheet" href="../styles/nav.css?v=2026.8">
     <script src="https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js"></script>
   </head><body>
 <div id="nav-placeholder"></div>
@@ -51,7 +51,7 @@
 
   <footer>
    </footer>
-  <script src="/scripts/nav.js?v=2026.6"></script>
-  <script src="/scripts/team.js?v=2026.6"></script>
+  <script src="/scripts/nav.js?v=2026.8"></script>
+  <script src="/scripts/team.js?v=2026.8"></script>
 </body>
 </html>

--- a/partials/nav.html
+++ b/partials/nav.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="../styles/nav.css?v=2026.6" />
+<link rel="stylesheet" href="../styles/nav.css?v=2026.8" />
 <header>
   <div class="announcement-banner">
     <div class="announcement-content">

--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -191,8 +191,8 @@ async function loadDashboard() {
 
   try {
     const [tueRes, wedRes, cancelRes] = await Promise.all([
-      fetch('teams/tuesday/schedules/master_schedule.json?v=2026'),
-      fetch('teams/wednesday/schedules/master_schedule.json?v=2026'),
+      fetch('teams/tuesday/schedules/master_schedule.json?v=2026.8'),
+      fetch('teams/wednesday/schedules/master_schedule.json?v=2026.8'),
       fetch('assets/cancellations.json?v=' + Date.now()).catch(() => null)
     ]);
 

--- a/scripts/team.js
+++ b/scripts/team.js
@@ -59,7 +59,7 @@ async function loadTeamData(scheduleUrl, rosterUrl) {
     (scheduleData.schedule || []).forEach(match => {
       const isCancelled = cancellationData.cancelledDate && match.date === cancellationData.cancelledDate && localTodayStr <= cancellationData.cancelledDate;
       const icsLink = match.ics
-        ? `<a href="${sanitizeUrl(match.ics)}?v=2026" download="LTTA-Match-Week${escapeHTML(match.week)}.ics" title="Add to calendar">📅</a>`
+        ? `<a href="${sanitizeUrl(match.ics)}?v=2026.8" download="LTTA-Match-Week${escapeHTML(match.week)}.ics" title="Add to calendar">📅</a>`
         : '';
       const tr = document.createElement("tr");
       if (isCancelled) {
@@ -100,7 +100,7 @@ async function loadTeamData(scheduleUrl, rosterUrl) {
     const teamIcsLink = document.getElementById('add-all-ics');
     if (teamIcsLink) {
       const baseIcsUrl = scheduleData.teamIcsPath || `/teams/${scheduleData.night}/ics/${scheduleData.team.replace(/\s+/g, '_')}/team.ics`;
-      teamIcsLink.href = sanitizeUrl(`${baseIcsUrl}?v=2026`);
+      teamIcsLink.href = sanitizeUrl(`${baseIcsUrl}?v=2026.8`);
     }
 
     highlightNextMatch();
@@ -159,6 +159,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const day = getDayFromUrl();
   if (team && day) {
     // Adjust path as needed for your structure
-    loadTeamData(`../teams/${day}/schedules/${team}.json`, `../teams/${day}/rosters/${team}.json`);
+    loadTeamData(`../teams/${day}/schedules/${team}.json?v=2026.8`, `../teams/${day}/rosters/${team}.json?v=2026.8`);
   }
 });

--- a/teams/tuesday/all.html
+++ b/teams/tuesday/all.html
@@ -210,18 +210,18 @@
       <tr class="date-row"><td colspan="3">23-Jun</td></tr>
       <tr class="court-row">
         <td class="court-header">Courts 1–5</td>
-        <td class="match-cell"><span class="team-num">9</span>Bounce It (h) vs <span class="team-num">7</span>Good Ol' Boys<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
-        <td class="match-cell"><span class="team-num">10</span>Jetsetters (h) vs <span class="team-num">6</span>Rascals<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">6</span>Rascals (h) vs <span class="team-num">11</span>Full Metal Racquet<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">5</span>Racquet Scientists (h) vs <span class="team-num">12</span>Easy Overhead<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
       <tr class="court-row">
         <td class="court-header">Courts 6–9</td>
-        <td class="match-cell"><span class="team-num">8</span>Return to Sender with Love (h) vs <span class="team-num">1</span>Spin Doctors<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
-        <td class="match-cell"><span class="team-num">11</span>Full Metal Racquet (h) vs <span class="team-num">5</span>Racquet Scientists<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">7</span>Good Ol' Boys (h) vs <span class="team-num">10</span>Jetsetters<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">4</span>Approach Shots (h) vs <span class="team-num">2</span>Subs<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
       <tr class="court-row">
         <td class="court-header">Courts 10–13</td>
-        <td class="match-cell"><span class="team-num">2</span>Subs (h) vs <span class="team-num">3</span>Herons<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
-        <td class="match-cell"><span class="team-num">12</span>Easy Overhead (h) vs <span class="team-num">4</span>Approach Shots<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">8</span>Return to Sender with Love (h) vs <span class="team-num">9</span>Bounce It<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">3</span>Herons (h) vs <span class="team-num">1</span>Spin Doctors<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
       <tr class="date-row"><td colspan="3">30-Jun</td></tr>
       <tr class="court-row">
@@ -290,18 +290,18 @@
       <tr class="date-row"><td colspan="3">28-Jul</td></tr>
       <tr class="court-row">
         <td class="court-header">Courts 1–5</td>
-        <td class="match-cell"><span class="team-num">6</span>Rascals (h) vs <span class="team-num">11</span>Full Metal Racquet<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
-        <td class="match-cell"><span class="team-num">5</span>Racquet Scientists (h) vs <span class="team-num">12</span>Easy Overhead<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">9</span>Bounce It (h) vs <span class="team-num">7</span>Good Ol' Boys<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">10</span>Jetsetters (h) vs <span class="team-num">6</span>Rascals<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
       <tr class="court-row">
         <td class="court-header">Courts 6–9</td>
-        <td class="match-cell"><span class="team-num">7</span>Good Ol' Boys (h) vs <span class="team-num">10</span>Jetsetters<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
-        <td class="match-cell"><span class="team-num">4</span>Approach Shots (h) vs <span class="team-num">2</span>Subs<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">8</span>Return to Sender with Love (h) vs <span class="team-num">1</span>Spin Doctors<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">11</span>Full Metal Racquet (h) vs <span class="team-num">5</span>Racquet Scientists<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
       <tr class="court-row">
         <td class="court-header">Courts 10–13</td>
-        <td class="match-cell"><span class="team-num">8</span>Return to Sender with Love (h) vs <span class="team-num">9</span>Bounce It<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
-        <td class="match-cell"><span class="team-num">3</span>Herons (h) vs <span class="team-num">1</span>Spin Doctors<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">2</span>Subs (h) vs <span class="team-num">3</span>Herons<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
+        <td class="match-cell"><span class="team-num">12</span>Easy Overhead (h) vs <span class="team-num">4</span>Approach Shots<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
       <tr class="date-row"><td colspan="3">4-Aug</td></tr>
       <tr class="court-row">
@@ -320,6 +320,6 @@
         <td class="match-cell"><span class="team-num">5</span>Racquet Scientists (h) vs <span class="team-num">10</span>Jetsetters<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
     </table>
-    <p style="text-align:center; font-size: 0.8em; color: #999;">Last Updated: 5/23/2026, 1:39:49 PM</p>
+    <p style="text-align:center; font-size: 0.8em; color: #999;">Last Updated: 6/21/2026, 7:10:07 AM</p>
   </body>
 </html>

--- a/teams/tuesday/ics/1/team.ics
+++ b/teams/tuesday/ics/1/team.ics
@@ -35,7 +35,7 @@ DTSTAMP:20260609T173000Z
 DTSTART;TZID=America/Chicago:20260609T173000
 DTEND;TZID=America/Chicago:20260609T190000
 SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 1 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 1 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -59,14 +59,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-1-week5@couleeregiontennis.org
-DTSTAMP:20260623T173000Z
-DTSTART;TZID=America/Chicago:20260623T173000
-DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Return to Sender with Love
-DESCRIPTION:LTTA Tennis match: 1 vs Return to Sender with Love at Green Island Park - Courts 6–9\nOpponent Roster: Denny Kreuser (1); Paul Leithold (2); Sara Bieneman (3); Missy Marcus (3); Julie Kamla (3); Asher Helgerson (3); Catherine Roraff (4); Mary Leithold (5)
-LOCATION:Green Island Park - Courts 6–9
+DTSTAMP:20260623T190000Z
+DTSTART;TZID=America/Chicago:20260623T190000
+DTEND;TZID=America/Chicago:20260623T203000
+SUMMARY:LTTA Tennis: vs Herons
+DESCRIPTION:LTTA Tennis match: 1 vs Herons at Green Island Park - Courts 10–13\nOpponent Roster: Stephan Brettfeld (1); Joe Gregas (2); Madeline Loh (3); Adrienne Loh (3); Stanton Loh (3); Malakai Berget (3); Kaitlyn Northrup (4); Steve Mydy (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM
@@ -129,14 +129,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-1-week10@couleeregiontennis.org
-DTSTAMP:20260728T190000Z
-DTSTART;TZID=America/Chicago:20260728T190000
-DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Herons
-DESCRIPTION:LTTA Tennis match: 1 vs Herons at Green Island Park - Courts 10–13\nOpponent Roster: Stephan Brettfeld (1); Joe Gregas (2); Madeline Loh (3); Adrienne Loh (3); Stanton Loh (3); Malakai Berget (3); Kaitlyn Northrup (4); Steve Mydy (5)
-LOCATION:Green Island Park - Courts 10–13
+DTSTAMP:20260728T173000Z
+DTSTART;TZID=America/Chicago:20260728T173000
+DTEND;TZID=America/Chicago:20260728T190000
+SUMMARY:LTTA Tennis: vs Return to Sender with Love
+DESCRIPTION:LTTA Tennis match: 1 vs Return to Sender with Love at Green Island Park - Courts 6–9\nOpponent Roster: Denny Kreuser (1); Paul Leithold (2); Sara Bieneman (3); Missy Marcus (3); Julie Kamla (3); Asher Helgerson (3); Catherine Roraff (4); Mary Leithold (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM
@@ -147,8 +147,7 @@ DTSTAMP:20260804T173000Z
 DTSTART;TZID=America/Chicago:20260804T173000
 DTEND;TZID=America/Chicago:20260804T190000
 SUMMARY:LTTA Tennis: vs Subs
-DESCRIPTION:LTTA Tennis match: 1 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 1 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/tuesday/ics/1/week10.ics
+++ b/teams/tuesday/ics/1/week10.ics
@@ -21,14 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-1-week10@couleeregiontennis.org
-DTSTAMP:20260728T190000Z
-DTSTART;TZID=America/Chicago:20260728T190000
-DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Herons (Away)
-DESCRIPTION:LTTA Tennis match: 1 vs Herons at Green Island Park - Courts 10–13\nOpponent Roster: Stephan Brettfeld (1); Joe Gregas (2); Madeline Loh (3); Adrienne Loh (3); Stanton Loh (3); Malakai Berget (3); Kaitlyn Northrup (4); Steve Mydy (5)
-LOCATION:Green Island Park - Courts 10–13
+DTSTAMP:20260728T173000Z
+DTSTART;TZID=America/Chicago:20260728T173000
+DTEND;TZID=America/Chicago:20260728T190000
+SUMMARY:LTTA Tennis: vs Return to Sender with Love (Away)
+DESCRIPTION:LTTA Tennis match: 1 vs Return to Sender with Love at Green Island Park - Courts 6–9\nOpponent Roster: Denny Kreuser (1); Paul Leithold (2); Sara Bieneman (3); Missy Marcus (3); Julie Kamla (3); Asher Helgerson (3); Catherine Roraff (4); Mary Leithold (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/1/week11.ics
+++ b/teams/tuesday/ics/1/week11.ics
@@ -25,8 +25,7 @@ DTSTAMP:20260804T173000Z
 DTSTART;TZID=America/Chicago:20260804T173000
 DTEND;TZID=America/Chicago:20260804T190000
 SUMMARY:LTTA Tennis: vs Subs (Home)
-DESCRIPTION:LTTA Tennis match: 1 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 1 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/tuesday/ics/1/week3.ics
+++ b/teams/tuesday/ics/1/week3.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260609T173000Z
 DTSTART;TZID=America/Chicago:20260609T173000
 DTEND;TZID=America/Chicago:20260609T190000
 SUMMARY:LTTA Tennis: vs Jetsetters (Away)
-DESCRIPTION:LTTA Tennis match: 1 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 1 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/tuesday/ics/1/week5.ics
+++ b/teams/tuesday/ics/1/week5.ics
@@ -21,14 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-1-week5@couleeregiontennis.org
-DTSTAMP:20260623T173000Z
-DTSTART;TZID=America/Chicago:20260623T173000
-DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Return to Sender with Love (Away)
-DESCRIPTION:LTTA Tennis match: 1 vs Return to Sender with Love at Green Island Park - Courts 6–9\nOpponent Roster: Denny Kreuser (1); Paul Leithold (2); Sara Bieneman (3); Missy Marcus (3); Julie Kamla (3); Asher Helgerson (3); Catherine Roraff (4); Mary Leithold (5)
-LOCATION:Green Island Park - Courts 6–9
+DTSTAMP:20260623T190000Z
+DTSTART;TZID=America/Chicago:20260623T190000
+DTEND;TZID=America/Chicago:20260623T203000
+SUMMARY:LTTA Tennis: vs Herons (Away)
+DESCRIPTION:LTTA Tennis match: 1 vs Herons at Green Island Park - Courts 10–13\nOpponent Roster: Stephan Brettfeld (1); Joe Gregas (2); Madeline Loh (3); Adrienne Loh (3); Stanton Loh (3); Malakai Berget (3); Kaitlyn Northrup (4); Steve Mydy (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/10/team.ics
+++ b/teams/tuesday/ics/10/team.ics
@@ -59,14 +59,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-10-week5@couleeregiontennis.org
-DTSTAMP:20260623T190000Z
-DTSTART;TZID=America/Chicago:20260623T190000
-DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Rascals
-DESCRIPTION:LTTA Tennis match: 10 vs Rascals at Green Island Park - Courts 1–5\nOpponent Roster: Peter Coppola (1); Fritz Wiggert (2); Ellen Seithamer (3); Margi Hanson (3); Craig Hanson (3); Jason Herbert (3); Erin Herbert (4); Becky Rauch (5)
-LOCATION:Green Island Park - Courts 1–5
+DTSTAMP:20260623T173000Z
+DTSTART;TZID=America/Chicago:20260623T173000
+DTEND;TZID=America/Chicago:20260623T190000
+SUMMARY:LTTA Tennis: vs Good Ol' Boys
+DESCRIPTION:LTTA Tennis match: 10 vs Good Ol' Boys at Green Island Park - Courts 6–9\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM
@@ -91,8 +91,7 @@ DTSTAMP:20260707T173000Z
 DTSTART;TZID=America/Chicago:20260707T173000
 DTEND;TZID=America/Chicago:20260707T190000
 SUMMARY:LTTA Tennis: vs Subs
-DESCRIPTION:LTTA Tennis match: 10 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 10 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -130,14 +129,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-10-week10@couleeregiontennis.org
-DTSTAMP:20260728T173000Z
-DTSTART;TZID=America/Chicago:20260728T173000
-DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Good Ol' Boys
-DESCRIPTION:LTTA Tennis match: 10 vs Good Ol' Boys at Green Island Park - Courts 6–9\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
-LOCATION:Green Island Park - Courts 6–9
+DTSTAMP:20260728T190000Z
+DTSTART;TZID=America/Chicago:20260728T190000
+DTEND;TZID=America/Chicago:20260728T203000
+SUMMARY:LTTA Tennis: vs Rascals
+DESCRIPTION:LTTA Tennis match: 10 vs Rascals at Green Island Park - Courts 1–5\nOpponent Roster: Peter Coppola (1); Fritz Wiggert (2); Ellen Seithamer (3); Margi Hanson (3); Craig Hanson (3); Jason Herbert (3); Erin Herbert (4); Becky Rauch (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/10/week10.ics
+++ b/teams/tuesday/ics/10/week10.ics
@@ -21,14 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-10-week10@couleeregiontennis.org
-DTSTAMP:20260728T173000Z
-DTSTART;TZID=America/Chicago:20260728T173000
-DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Good Ol' Boys (Away)
-DESCRIPTION:LTTA Tennis match: 10 vs Good Ol' Boys at Green Island Park - Courts 6–9\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
-LOCATION:Green Island Park - Courts 6–9
+DTSTAMP:20260728T190000Z
+DTSTART;TZID=America/Chicago:20260728T190000
+DTEND;TZID=America/Chicago:20260728T203000
+SUMMARY:LTTA Tennis: vs Rascals (Home)
+DESCRIPTION:LTTA Tennis match: 10 vs Rascals at Green Island Park - Courts 1–5\nOpponent Roster: Peter Coppola (1); Fritz Wiggert (2); Ellen Seithamer (3); Margi Hanson (3); Craig Hanson (3); Jason Herbert (3); Erin Herbert (4); Becky Rauch (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/10/week5.ics
+++ b/teams/tuesday/ics/10/week5.ics
@@ -21,14 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-10-week5@couleeregiontennis.org
-DTSTAMP:20260623T190000Z
-DTSTART;TZID=America/Chicago:20260623T190000
-DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Rascals (Home)
-DESCRIPTION:LTTA Tennis match: 10 vs Rascals at Green Island Park - Courts 1–5\nOpponent Roster: Peter Coppola (1); Fritz Wiggert (2); Ellen Seithamer (3); Margi Hanson (3); Craig Hanson (3); Jason Herbert (3); Erin Herbert (4); Becky Rauch (5)
-LOCATION:Green Island Park - Courts 1–5
+DTSTAMP:20260623T173000Z
+DTSTART;TZID=America/Chicago:20260623T173000
+DTEND;TZID=America/Chicago:20260623T190000
+SUMMARY:LTTA Tennis: vs Good Ol' Boys (Away)
+DESCRIPTION:LTTA Tennis match: 10 vs Good Ol' Boys at Green Island Park - Courts 6–9\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/10/week7.ics
+++ b/teams/tuesday/ics/10/week7.ics
@@ -25,8 +25,7 @@ DTSTAMP:20260707T173000Z
 DTSTART;TZID=America/Chicago:20260707T173000
 DTEND;TZID=America/Chicago:20260707T190000
 SUMMARY:LTTA Tennis: vs Subs (Home)
-DESCRIPTION:LTTA Tennis match: 10 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 10 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/tuesday/ics/11/team.ics
+++ b/teams/tuesday/ics/11/team.ics
@@ -7,8 +7,7 @@ DTSTAMP:20260526T190000Z
 DTSTART;TZID=America/Chicago:20260526T190000
 DTEND;TZID=America/Chicago:20260526T203000
 SUMMARY:LTTA Tennis: vs Subs
-DESCRIPTION:LTTA Tennis match: 11 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 11 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -60,14 +59,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-11-week5@couleeregiontennis.org
-DTSTAMP:20260623T190000Z
-DTSTART;TZID=America/Chicago:20260623T190000
-DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Racquet Scientists
-DESCRIPTION:LTTA Tennis match: 11 vs Racquet Scientists at Green Island Park - Courts 6–9\nOpponent Roster: Mark Harris (1); Nathan Tunks (2); Gavin Goss (3); Frank Schwarz (3); Nancy Winberg (3); Karie Johnson (3); Kim Thurk (4); Morgan McBride (5)
-LOCATION:Green Island Park - Courts 6–9
+DTSTAMP:20260623T173000Z
+DTSTART;TZID=America/Chicago:20260623T173000
+DTEND;TZID=America/Chicago:20260623T190000
+SUMMARY:LTTA Tennis: vs Rascals
+DESCRIPTION:LTTA Tennis match: 11 vs Rascals at Green Island Park - Courts 1–5\nOpponent Roster: Peter Coppola (1); Fritz Wiggert (2); Ellen Seithamer (3); Margi Hanson (3); Craig Hanson (3); Jason Herbert (3); Erin Herbert (4); Becky Rauch (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM
@@ -106,7 +105,7 @@ DTSTAMP:20260714T173000Z
 DTSTART;TZID=America/Chicago:20260714T173000
 DTEND;TZID=America/Chicago:20260714T190000
 SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 11 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 11 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -130,14 +129,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-11-week10@couleeregiontennis.org
-DTSTAMP:20260728T173000Z
-DTSTART;TZID=America/Chicago:20260728T173000
-DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Rascals
-DESCRIPTION:LTTA Tennis match: 11 vs Rascals at Green Island Park - Courts 1–5\nOpponent Roster: Peter Coppola (1); Fritz Wiggert (2); Ellen Seithamer (3); Margi Hanson (3); Craig Hanson (3); Jason Herbert (3); Erin Herbert (4); Becky Rauch (5)
-LOCATION:Green Island Park - Courts 1–5
+DTSTAMP:20260728T190000Z
+DTSTART;TZID=America/Chicago:20260728T190000
+DTEND;TZID=America/Chicago:20260728T203000
+SUMMARY:LTTA Tennis: vs Racquet Scientists
+DESCRIPTION:LTTA Tennis match: 11 vs Racquet Scientists at Green Island Park - Courts 6–9\nOpponent Roster: Mark Harris (1); Nathan Tunks (2); Gavin Goss (3); Frank Schwarz (3); Nancy Winberg (3); Karie Johnson (3); Kim Thurk (4); Morgan McBride (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/11/week1.ics
+++ b/teams/tuesday/ics/11/week1.ics
@@ -25,8 +25,7 @@ DTSTAMP:20260526T190000Z
 DTSTART;TZID=America/Chicago:20260526T190000
 DTEND;TZID=America/Chicago:20260526T203000
 SUMMARY:LTTA Tennis: vs Subs (Away)
-DESCRIPTION:LTTA Tennis match: 11 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 11 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/tuesday/ics/11/week10.ics
+++ b/teams/tuesday/ics/11/week10.ics
@@ -21,14 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-11-week10@couleeregiontennis.org
-DTSTAMP:20260728T173000Z
-DTSTART;TZID=America/Chicago:20260728T173000
-DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Rascals (Away)
-DESCRIPTION:LTTA Tennis match: 11 vs Rascals at Green Island Park - Courts 1–5\nOpponent Roster: Peter Coppola (1); Fritz Wiggert (2); Ellen Seithamer (3); Margi Hanson (3); Craig Hanson (3); Jason Herbert (3); Erin Herbert (4); Becky Rauch (5)
-LOCATION:Green Island Park - Courts 1–5
+DTSTAMP:20260728T190000Z
+DTSTART;TZID=America/Chicago:20260728T190000
+DTEND;TZID=America/Chicago:20260728T203000
+SUMMARY:LTTA Tennis: vs Racquet Scientists (Home)
+DESCRIPTION:LTTA Tennis match: 11 vs Racquet Scientists at Green Island Park - Courts 6–9\nOpponent Roster: Mark Harris (1); Nathan Tunks (2); Gavin Goss (3); Frank Schwarz (3); Nancy Winberg (3); Karie Johnson (3); Kim Thurk (4); Morgan McBride (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/11/week5.ics
+++ b/teams/tuesday/ics/11/week5.ics
@@ -21,14 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-11-week5@couleeregiontennis.org
-DTSTAMP:20260623T190000Z
-DTSTART;TZID=America/Chicago:20260623T190000
-DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Racquet Scientists (Home)
-DESCRIPTION:LTTA Tennis match: 11 vs Racquet Scientists at Green Island Park - Courts 6–9\nOpponent Roster: Mark Harris (1); Nathan Tunks (2); Gavin Goss (3); Frank Schwarz (3); Nancy Winberg (3); Karie Johnson (3); Kim Thurk (4); Morgan McBride (5)
-LOCATION:Green Island Park - Courts 6–9
+DTSTAMP:20260623T173000Z
+DTSTART;TZID=America/Chicago:20260623T173000
+DTEND;TZID=America/Chicago:20260623T190000
+SUMMARY:LTTA Tennis: vs Rascals (Away)
+DESCRIPTION:LTTA Tennis match: 11 vs Rascals at Green Island Park - Courts 1–5\nOpponent Roster: Peter Coppola (1); Fritz Wiggert (2); Ellen Seithamer (3); Margi Hanson (3); Craig Hanson (3); Jason Herbert (3); Erin Herbert (4); Becky Rauch (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/11/week8.ics
+++ b/teams/tuesday/ics/11/week8.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260714T173000Z
 DTSTART;TZID=America/Chicago:20260714T173000
 DTEND;TZID=America/Chicago:20260714T190000
 SUMMARY:LTTA Tennis: vs Jetsetters (Away)
-DESCRIPTION:LTTA Tennis match: 11 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 11 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/tuesday/ics/12/team.ics
+++ b/teams/tuesday/ics/12/team.ics
@@ -21,7 +21,7 @@ DTSTAMP:20260602T190000Z
 DTSTART;TZID=America/Chicago:20260602T190000
 DTEND;TZID=America/Chicago:20260602T203000
 SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 12 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 12 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -62,9 +62,9 @@ UID:ltta-tuesday-12-week5@couleeregiontennis.org
 DTSTAMP:20260623T190000Z
 DTSTART;TZID=America/Chicago:20260623T190000
 DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Approach Shots
-DESCRIPTION:LTTA Tennis match: 12 vs Approach Shots at Green Island Park - Courts 10–13\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
-LOCATION:Green Island Park - Courts 10–13
+SUMMARY:LTTA Tennis: vs Racquet Scientists
+DESCRIPTION:LTTA Tennis match: 12 vs Racquet Scientists at Green Island Park - Courts 1–5\nOpponent Roster: Mark Harris (1); Nathan Tunks (2); Gavin Goss (3); Frank Schwarz (3); Nancy Winberg (3); Karie Johnson (3); Kim Thurk (4); Morgan McBride (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY
@@ -77,8 +77,7 @@ DTSTAMP:20260630T190000Z
 DTSTART;TZID=America/Chicago:20260630T190000
 DTEND;TZID=America/Chicago:20260630T203000
 SUMMARY:LTTA Tennis: vs Subs
-DESCRIPTION:LTTA Tennis match: 12 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 12 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -133,9 +132,9 @@ UID:ltta-tuesday-12-week10@couleeregiontennis.org
 DTSTAMP:20260728T190000Z
 DTSTART;TZID=America/Chicago:20260728T190000
 DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Racquet Scientists
-DESCRIPTION:LTTA Tennis match: 12 vs Racquet Scientists at Green Island Park - Courts 1–5\nOpponent Roster: Mark Harris (1); Nathan Tunks (2); Gavin Goss (3); Frank Schwarz (3); Nancy Winberg (3); Karie Johnson (3); Kim Thurk (4); Morgan McBride (5)
-LOCATION:Green Island Park - Courts 1–5
+SUMMARY:LTTA Tennis: vs Approach Shots
+DESCRIPTION:LTTA Tennis match: 12 vs Approach Shots at Green Island Park - Courts 10–13\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY

--- a/teams/tuesday/ics/12/week10.ics
+++ b/teams/tuesday/ics/12/week10.ics
@@ -24,9 +24,9 @@ UID:ltta-tuesday-12-week10@couleeregiontennis.org
 DTSTAMP:20260728T190000Z
 DTSTART;TZID=America/Chicago:20260728T190000
 DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Racquet Scientists (Away)
-DESCRIPTION:LTTA Tennis match: 12 vs Racquet Scientists at Green Island Park - Courts 1–5\nOpponent Roster: Mark Harris (1); Nathan Tunks (2); Gavin Goss (3); Frank Schwarz (3); Nancy Winberg (3); Karie Johnson (3); Kim Thurk (4); Morgan McBride (5)
-LOCATION:Green Island Park - Courts 1–5
+SUMMARY:LTTA Tennis: vs Approach Shots (Home)
+DESCRIPTION:LTTA Tennis match: 12 vs Approach Shots at Green Island Park - Courts 10–13\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY

--- a/teams/tuesday/ics/12/week2.ics
+++ b/teams/tuesday/ics/12/week2.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260602T190000Z
 DTSTART;TZID=America/Chicago:20260602T190000
 DTEND;TZID=America/Chicago:20260602T203000
 SUMMARY:LTTA Tennis: vs Jetsetters (Home)
-DESCRIPTION:LTTA Tennis match: 12 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 12 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/tuesday/ics/12/week5.ics
+++ b/teams/tuesday/ics/12/week5.ics
@@ -24,9 +24,9 @@ UID:ltta-tuesday-12-week5@couleeregiontennis.org
 DTSTAMP:20260623T190000Z
 DTSTART;TZID=America/Chicago:20260623T190000
 DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Approach Shots (Home)
-DESCRIPTION:LTTA Tennis match: 12 vs Approach Shots at Green Island Park - Courts 10–13\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
-LOCATION:Green Island Park - Courts 10–13
+SUMMARY:LTTA Tennis: vs Racquet Scientists (Away)
+DESCRIPTION:LTTA Tennis match: 12 vs Racquet Scientists at Green Island Park - Courts 1–5\nOpponent Roster: Mark Harris (1); Nathan Tunks (2); Gavin Goss (3); Frank Schwarz (3); Nancy Winberg (3); Karie Johnson (3); Kim Thurk (4); Morgan McBride (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY

--- a/teams/tuesday/ics/12/week6.ics
+++ b/teams/tuesday/ics/12/week6.ics
@@ -25,8 +25,7 @@ DTSTAMP:20260630T190000Z
 DTSTART;TZID=America/Chicago:20260630T190000
 DTEND;TZID=America/Chicago:20260630T203000
 SUMMARY:LTTA Tennis: vs Subs (Home)
-DESCRIPTION:LTTA Tennis match: 12 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 12 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/tuesday/ics/2/team.ics
+++ b/teams/tuesday/ics/2/team.ics
@@ -59,14 +59,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-2-week5@couleeregiontennis.org
-DTSTAMP:20260623T173000Z
-DTSTART;TZID=America/Chicago:20260623T173000
-DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Herons
-DESCRIPTION:LTTA Tennis match: 2 vs Herons at Green Island Park - Courts 10–13\nOpponent Roster: Stephan Brettfeld (1); Joe Gregas (2); Madeline Loh (3); Adrienne Loh (3); Stanton Loh (3); Malakai Berget (3); Kaitlyn Northrup (4); Steve Mydy (5)
-LOCATION:Green Island Park - Courts 10–13
+DTSTAMP:20260623T190000Z
+DTSTART;TZID=America/Chicago:20260623T190000
+DTEND;TZID=America/Chicago:20260623T203000
+SUMMARY:LTTA Tennis: vs Approach Shots
+DESCRIPTION:LTTA Tennis match: 2 vs Approach Shots at Green Island Park - Courts 6–9\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM
@@ -91,7 +91,7 @@ DTSTAMP:20260707T173000Z
 DTSTART;TZID=America/Chicago:20260707T173000
 DTEND;TZID=America/Chicago:20260707T190000
 SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 2 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 2 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -129,14 +129,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-2-week10@couleeregiontennis.org
-DTSTAMP:20260728T190000Z
-DTSTART;TZID=America/Chicago:20260728T190000
-DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Approach Shots
-DESCRIPTION:LTTA Tennis match: 2 vs Approach Shots at Green Island Park - Courts 6–9\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
-LOCATION:Green Island Park - Courts 6–9
+DTSTAMP:20260728T173000Z
+DTSTART;TZID=America/Chicago:20260728T173000
+DTEND;TZID=America/Chicago:20260728T190000
+SUMMARY:LTTA Tennis: vs Herons
+DESCRIPTION:LTTA Tennis match: 2 vs Herons at Green Island Park - Courts 10–13\nOpponent Roster: Stephan Brettfeld (1); Joe Gregas (2); Madeline Loh (3); Adrienne Loh (3); Stanton Loh (3); Malakai Berget (3); Kaitlyn Northrup (4); Steve Mydy (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/2/week10.ics
+++ b/teams/tuesday/ics/2/week10.ics
@@ -21,14 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-2-week10@couleeregiontennis.org
-DTSTAMP:20260728T190000Z
-DTSTART;TZID=America/Chicago:20260728T190000
-DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Approach Shots (Away)
-DESCRIPTION:LTTA Tennis match: 2 vs Approach Shots at Green Island Park - Courts 6–9\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
-LOCATION:Green Island Park - Courts 6–9
+DTSTAMP:20260728T173000Z
+DTSTART;TZID=America/Chicago:20260728T173000
+DTEND;TZID=America/Chicago:20260728T190000
+SUMMARY:LTTA Tennis: vs Herons (Home)
+DESCRIPTION:LTTA Tennis match: 2 vs Herons at Green Island Park - Courts 10–13\nOpponent Roster: Stephan Brettfeld (1); Joe Gregas (2); Madeline Loh (3); Adrienne Loh (3); Stanton Loh (3); Malakai Berget (3); Kaitlyn Northrup (4); Steve Mydy (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/2/week5.ics
+++ b/teams/tuesday/ics/2/week5.ics
@@ -21,14 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-2-week5@couleeregiontennis.org
-DTSTAMP:20260623T173000Z
-DTSTART;TZID=America/Chicago:20260623T173000
-DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Herons (Home)
-DESCRIPTION:LTTA Tennis match: 2 vs Herons at Green Island Park - Courts 10–13\nOpponent Roster: Stephan Brettfeld (1); Joe Gregas (2); Madeline Loh (3); Adrienne Loh (3); Stanton Loh (3); Malakai Berget (3); Kaitlyn Northrup (4); Steve Mydy (5)
-LOCATION:Green Island Park - Courts 10–13
+DTSTAMP:20260623T190000Z
+DTSTART;TZID=America/Chicago:20260623T190000
+DTEND;TZID=America/Chicago:20260623T203000
+SUMMARY:LTTA Tennis: vs Approach Shots (Away)
+DESCRIPTION:LTTA Tennis match: 2 vs Approach Shots at Green Island Park - Courts 6–9\nOpponent Roster: Greg Schibbelhut (1); Dillon Eddingsaas (2); Matthew Isaacson (3); Mary Aschenbrenner (3); Dale Barclay (3); Rich Levinger (3); Judith Engen (4); Amanda Wilke (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/2/week7.ics
+++ b/teams/tuesday/ics/2/week7.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260707T173000Z
 DTSTART;TZID=America/Chicago:20260707T173000
 DTEND;TZID=America/Chicago:20260707T190000
 SUMMARY:LTTA Tennis: vs Jetsetters (Away)
-DESCRIPTION:LTTA Tennis match: 2 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 2 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/tuesday/ics/3/team.ics
+++ b/teams/tuesday/ics/3/team.ics
@@ -7,7 +7,7 @@ DTSTAMP:20260526T173000Z
 DTSTART;TZID=America/Chicago:20260526T173000
 DTEND;TZID=America/Chicago:20260526T190000
 SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 3 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 3 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -59,15 +59,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-3-week5@couleeregiontennis.org
-DTSTAMP:20260623T173000Z
-DTSTART;TZID=America/Chicago:20260623T173000
-DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Subs
-DESCRIPTION:LTTA Tennis match: 3 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DTSTAMP:20260623T190000Z
+DTSTART;TZID=America/Chicago:20260623T190000
+DTEND;TZID=America/Chicago:20260623T203000
+SUMMARY:LTTA Tennis: vs Spin Doctors
+DESCRIPTION:LTTA Tennis match: 3 vs Spin Doctors at Green Island Park - Courts 10–13\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM
@@ -130,14 +129,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-3-week10@couleeregiontennis.org
-DTSTAMP:20260728T190000Z
-DTSTART;TZID=America/Chicago:20260728T190000
-DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Spin Doctors
-DESCRIPTION:LTTA Tennis match: 3 vs Spin Doctors at Green Island Park - Courts 10–13\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
+DTSTAMP:20260728T173000Z
+DTSTART;TZID=America/Chicago:20260728T173000
+DTEND;TZID=America/Chicago:20260728T190000
+SUMMARY:LTTA Tennis: vs Subs
+DESCRIPTION:LTTA Tennis match: 3 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/3/week1.ics
+++ b/teams/tuesday/ics/3/week1.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260526T173000Z
 DTSTART;TZID=America/Chicago:20260526T173000
 DTEND;TZID=America/Chicago:20260526T190000
 SUMMARY:LTTA Tennis: vs Jetsetters (Home)
-DESCRIPTION:LTTA Tennis match: 3 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 3 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/tuesday/ics/3/week10.ics
+++ b/teams/tuesday/ics/3/week10.ics
@@ -21,14 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-3-week10@couleeregiontennis.org
-DTSTAMP:20260728T190000Z
-DTSTART;TZID=America/Chicago:20260728T190000
-DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Spin Doctors (Home)
-DESCRIPTION:LTTA Tennis match: 3 vs Spin Doctors at Green Island Park - Courts 10–13\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
+DTSTAMP:20260728T173000Z
+DTSTART;TZID=America/Chicago:20260728T173000
+DTEND;TZID=America/Chicago:20260728T190000
+SUMMARY:LTTA Tennis: vs Subs (Away)
+DESCRIPTION:LTTA Tennis match: 3 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/3/week5.ics
+++ b/teams/tuesday/ics/3/week5.ics
@@ -21,15 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-3-week5@couleeregiontennis.org
-DTSTAMP:20260623T173000Z
-DTSTART;TZID=America/Chicago:20260623T173000
-DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Subs (Away)
-DESCRIPTION:LTTA Tennis match: 3 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DTSTAMP:20260623T190000Z
+DTSTART;TZID=America/Chicago:20260623T190000
+DTEND;TZID=America/Chicago:20260623T203000
+SUMMARY:LTTA Tennis: vs Spin Doctors (Home)
+DESCRIPTION:LTTA Tennis match: 3 vs Spin Doctors at Green Island Park - Courts 10–13\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/4/team.ics
+++ b/teams/tuesday/ics/4/team.ics
@@ -62,9 +62,9 @@ UID:ltta-tuesday-4-week5@couleeregiontennis.org
 DTSTAMP:20260623T190000Z
 DTSTART;TZID=America/Chicago:20260623T190000
 DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Easy Overhead
-DESCRIPTION:LTTA Tennis match: 4 vs Easy Overhead at Green Island Park - Courts 10–13\nOpponent Roster: Brian Mansky (1); Ryan Mullaney (2); Heidi Barreyro (3); Shanon Torgerud (3); Odessa Barreyro (3); Katie Johnson (3); Amit Mishra (4); Dwight Mills (5)
-LOCATION:Green Island Park - Courts 10–13
+SUMMARY:LTTA Tennis: vs Subs
+DESCRIPTION:LTTA Tennis match: 4 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY
@@ -77,7 +77,7 @@ DTSTAMP:20260630T173000Z
 DTSTART;TZID=America/Chicago:20260630T173000
 DTEND;TZID=America/Chicago:20260630T190000
 SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 4 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 4 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -132,10 +132,9 @@ UID:ltta-tuesday-4-week10@couleeregiontennis.org
 DTSTAMP:20260728T190000Z
 DTSTART;TZID=America/Chicago:20260728T190000
 DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Subs
-DESCRIPTION:LTTA Tennis match: 4 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
-LOCATION:Green Island Park - Courts 6–9
+SUMMARY:LTTA Tennis: vs Easy Overhead
+DESCRIPTION:LTTA Tennis match: 4 vs Easy Overhead at Green Island Park - Courts 10–13\nOpponent Roster: Brian Mansky (1); Ryan Mullaney (2); Heidi Barreyro (3); Shanon Torgerud (3); Odessa Barreyro (3); Katie Johnson (3); Amit Mishra (4); Dwight Mills (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY

--- a/teams/tuesday/ics/4/week10.ics
+++ b/teams/tuesday/ics/4/week10.ics
@@ -24,10 +24,9 @@ UID:ltta-tuesday-4-week10@couleeregiontennis.org
 DTSTAMP:20260728T190000Z
 DTSTART;TZID=America/Chicago:20260728T190000
 DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Subs (Home)
-DESCRIPTION:LTTA Tennis match: 4 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
-LOCATION:Green Island Park - Courts 6–9
+SUMMARY:LTTA Tennis: vs Easy Overhead (Away)
+DESCRIPTION:LTTA Tennis match: 4 vs Easy Overhead at Green Island Park - Courts 10–13\nOpponent Roster: Brian Mansky (1); Ryan Mullaney (2); Heidi Barreyro (3); Shanon Torgerud (3); Odessa Barreyro (3); Katie Johnson (3); Amit Mishra (4); Dwight Mills (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY

--- a/teams/tuesday/ics/4/week5.ics
+++ b/teams/tuesday/ics/4/week5.ics
@@ -24,9 +24,9 @@ UID:ltta-tuesday-4-week5@couleeregiontennis.org
 DTSTAMP:20260623T190000Z
 DTSTART;TZID=America/Chicago:20260623T190000
 DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Easy Overhead (Away)
-DESCRIPTION:LTTA Tennis match: 4 vs Easy Overhead at Green Island Park - Courts 10–13\nOpponent Roster: Brian Mansky (1); Ryan Mullaney (2); Heidi Barreyro (3); Shanon Torgerud (3); Odessa Barreyro (3); Katie Johnson (3); Amit Mishra (4); Dwight Mills (5)
-LOCATION:Green Island Park - Courts 10–13
+SUMMARY:LTTA Tennis: vs Subs (Home)
+DESCRIPTION:LTTA Tennis match: 4 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY

--- a/teams/tuesday/ics/4/week6.ics
+++ b/teams/tuesday/ics/4/week6.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260630T173000Z
 DTSTART;TZID=America/Chicago:20260630T173000
 DTEND;TZID=America/Chicago:20260630T190000
 SUMMARY:LTTA Tennis: vs Jetsetters (Home)
-DESCRIPTION:LTTA Tennis match: 4 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 4 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/tuesday/ics/5/team.ics
+++ b/teams/tuesday/ics/5/team.ics
@@ -49,8 +49,7 @@ DTSTAMP:20260616T190000Z
 DTSTART;TZID=America/Chicago:20260616T190000
 DTEND;TZID=America/Chicago:20260616T203000
 SUMMARY:LTTA Tennis: vs Subs
-DESCRIPTION:LTTA Tennis match: 5 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 5 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -63,9 +62,9 @@ UID:ltta-tuesday-5-week5@couleeregiontennis.org
 DTSTAMP:20260623T190000Z
 DTSTART;TZID=America/Chicago:20260623T190000
 DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Full Metal Racquet
-DESCRIPTION:LTTA Tennis match: 5 vs Full Metal Racquet at Green Island Park - Courts 6–9\nOpponent Roster: Jeff Herde (1); Cole Lapp (2); Bill Lapp (3); Regina Jones (3); Sam Schmidt (3); Hannah Exner (3); Sarah Gang (4); Morgan Brazil (5)
-LOCATION:Green Island Park - Courts 6–9
+SUMMARY:LTTA Tennis: vs Easy Overhead
+DESCRIPTION:LTTA Tennis match: 5 vs Easy Overhead at Green Island Park - Courts 1–5\nOpponent Roster: Brian Mansky (1); Ryan Mullaney (2); Heidi Barreyro (3); Shanon Torgerud (3); Odessa Barreyro (3); Katie Johnson (3); Amit Mishra (4); Dwight Mills (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY
@@ -133,9 +132,9 @@ UID:ltta-tuesday-5-week10@couleeregiontennis.org
 DTSTAMP:20260728T190000Z
 DTSTART;TZID=America/Chicago:20260728T190000
 DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Easy Overhead
-DESCRIPTION:LTTA Tennis match: 5 vs Easy Overhead at Green Island Park - Courts 1–5\nOpponent Roster: Brian Mansky (1); Ryan Mullaney (2); Heidi Barreyro (3); Shanon Torgerud (3); Odessa Barreyro (3); Katie Johnson (3); Amit Mishra (4); Dwight Mills (5)
-LOCATION:Green Island Park - Courts 1–5
+SUMMARY:LTTA Tennis: vs Full Metal Racquet
+DESCRIPTION:LTTA Tennis match: 5 vs Full Metal Racquet at Green Island Park - Courts 6–9\nOpponent Roster: Jeff Herde (1); Cole Lapp (2); Bill Lapp (3); Regina Jones (3); Sam Schmidt (3); Hannah Exner (3); Sarah Gang (4); Morgan Brazil (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY
@@ -148,7 +147,7 @@ DTSTAMP:20260804T190000Z
 DTSTART;TZID=America/Chicago:20260804T190000
 DTEND;TZID=America/Chicago:20260804T203000
 SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 5 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 5 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/tuesday/ics/5/week10.ics
+++ b/teams/tuesday/ics/5/week10.ics
@@ -24,9 +24,9 @@ UID:ltta-tuesday-5-week10@couleeregiontennis.org
 DTSTAMP:20260728T190000Z
 DTSTART;TZID=America/Chicago:20260728T190000
 DTEND;TZID=America/Chicago:20260728T203000
-SUMMARY:LTTA Tennis: vs Easy Overhead (Home)
-DESCRIPTION:LTTA Tennis match: 5 vs Easy Overhead at Green Island Park - Courts 1–5\nOpponent Roster: Brian Mansky (1); Ryan Mullaney (2); Heidi Barreyro (3); Shanon Torgerud (3); Odessa Barreyro (3); Katie Johnson (3); Amit Mishra (4); Dwight Mills (5)
-LOCATION:Green Island Park - Courts 1–5
+SUMMARY:LTTA Tennis: vs Full Metal Racquet (Away)
+DESCRIPTION:LTTA Tennis match: 5 vs Full Metal Racquet at Green Island Park - Courts 6–9\nOpponent Roster: Jeff Herde (1); Cole Lapp (2); Bill Lapp (3); Regina Jones (3); Sam Schmidt (3); Hannah Exner (3); Sarah Gang (4); Morgan Brazil (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY

--- a/teams/tuesday/ics/5/week11.ics
+++ b/teams/tuesday/ics/5/week11.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260804T190000Z
 DTSTART;TZID=America/Chicago:20260804T190000
 DTEND;TZID=America/Chicago:20260804T203000
 SUMMARY:LTTA Tennis: vs Jetsetters (Home)
-DESCRIPTION:LTTA Tennis match: 5 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 5 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/tuesday/ics/5/week4.ics
+++ b/teams/tuesday/ics/5/week4.ics
@@ -25,8 +25,7 @@ DTSTAMP:20260616T190000Z
 DTSTART;TZID=America/Chicago:20260616T190000
 DTEND;TZID=America/Chicago:20260616T203000
 SUMMARY:LTTA Tennis: vs Subs (Away)
-DESCRIPTION:LTTA Tennis match: 5 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 5 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/tuesday/ics/5/week5.ics
+++ b/teams/tuesday/ics/5/week5.ics
@@ -24,9 +24,9 @@ UID:ltta-tuesday-5-week5@couleeregiontennis.org
 DTSTAMP:20260623T190000Z
 DTSTART;TZID=America/Chicago:20260623T190000
 DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Full Metal Racquet (Away)
-DESCRIPTION:LTTA Tennis match: 5 vs Full Metal Racquet at Green Island Park - Courts 6–9\nOpponent Roster: Jeff Herde (1); Cole Lapp (2); Bill Lapp (3); Regina Jones (3); Sam Schmidt (3); Hannah Exner (3); Sarah Gang (4); Morgan Brazil (5)
-LOCATION:Green Island Park - Courts 6–9
+SUMMARY:LTTA Tennis: vs Easy Overhead (Home)
+DESCRIPTION:LTTA Tennis match: 5 vs Easy Overhead at Green Island Park - Courts 1–5\nOpponent Roster: Brian Mansky (1); Ryan Mullaney (2); Heidi Barreyro (3); Shanon Torgerud (3); Odessa Barreyro (3); Katie Johnson (3); Amit Mishra (4); Dwight Mills (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H
 ACTION:DISPLAY

--- a/teams/tuesday/ics/6/team.ics
+++ b/teams/tuesday/ics/6/team.ics
@@ -59,14 +59,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-6-week5@couleeregiontennis.org
-DTSTAMP:20260623T190000Z
-DTSTART;TZID=America/Chicago:20260623T190000
-DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 6 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DTSTAMP:20260623T173000Z
+DTSTART;TZID=America/Chicago:20260623T173000
+DTEND;TZID=America/Chicago:20260623T190000
+SUMMARY:LTTA Tennis: vs Full Metal Racquet
+DESCRIPTION:LTTA Tennis match: 6 vs Full Metal Racquet at Green Island Park - Courts 1–5\nOpponent Roster: Jeff Herde (1); Cole Lapp (2); Bill Lapp (3); Regina Jones (3); Sam Schmidt (3); Hannah Exner (3); Sarah Gang (4); Morgan Brazil (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM
@@ -119,8 +119,7 @@ DTSTAMP:20260721T190000Z
 DTSTART;TZID=America/Chicago:20260721T190000
 DTEND;TZID=America/Chicago:20260721T203000
 SUMMARY:LTTA Tennis: vs Subs
-DESCRIPTION:LTTA Tennis match: 6 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 6 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -130,14 +129,14 @@ END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 UID:ltta-tuesday-6-week10@couleeregiontennis.org
-DTSTAMP:20260728T173000Z
-DTSTART;TZID=America/Chicago:20260728T173000
-DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Full Metal Racquet
-DESCRIPTION:LTTA Tennis match: 6 vs Full Metal Racquet at Green Island Park - Courts 1–5\nOpponent Roster: Jeff Herde (1); Cole Lapp (2); Bill Lapp (3); Regina Jones (3); Sam Schmidt (3); Hannah Exner (3); Sarah Gang (4); Morgan Brazil (5)
+DTSTAMP:20260728T190000Z
+DTSTART;TZID=America/Chicago:20260728T190000
+DTEND;TZID=America/Chicago:20260728T203000
+SUMMARY:LTTA Tennis: vs Jetsetters
+DESCRIPTION:LTTA Tennis match: 6 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/6/week10.ics
+++ b/teams/tuesday/ics/6/week10.ics
@@ -21,14 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-6-week10@couleeregiontennis.org
-DTSTAMP:20260728T173000Z
-DTSTART;TZID=America/Chicago:20260728T173000
-DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Full Metal Racquet (Home)
-DESCRIPTION:LTTA Tennis match: 6 vs Full Metal Racquet at Green Island Park - Courts 1–5\nOpponent Roster: Jeff Herde (1); Cole Lapp (2); Bill Lapp (3); Regina Jones (3); Sam Schmidt (3); Hannah Exner (3); Sarah Gang (4); Morgan Brazil (5)
+DTSTAMP:20260728T190000Z
+DTSTART;TZID=America/Chicago:20260728T190000
+DTEND;TZID=America/Chicago:20260728T203000
+SUMMARY:LTTA Tennis: vs Jetsetters (Away)
+DESCRIPTION:LTTA Tennis match: 6 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
-TRIGGER:-PT9H30M
+TRIGGER:-PT11H
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/6/week5.ics
+++ b/teams/tuesday/ics/6/week5.ics
@@ -21,14 +21,14 @@ END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
 UID:ltta-tuesday-6-week5@couleeregiontennis.org
-DTSTAMP:20260623T190000Z
-DTSTART;TZID=America/Chicago:20260623T190000
-DTEND;TZID=America/Chicago:20260623T203000
-SUMMARY:LTTA Tennis: vs Jetsetters (Away)
-DESCRIPTION:LTTA Tennis match: 6 vs Jetsetters at Green Island Park - Courts 1–5\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DTSTAMP:20260623T173000Z
+DTSTART;TZID=America/Chicago:20260623T173000
+DTEND;TZID=America/Chicago:20260623T190000
+SUMMARY:LTTA Tennis: vs Full Metal Racquet (Home)
+DESCRIPTION:LTTA Tennis match: 6 vs Full Metal Racquet at Green Island Park - Courts 1–5\nOpponent Roster: Jeff Herde (1); Cole Lapp (2); Bill Lapp (3); Regina Jones (3); Sam Schmidt (3); Hannah Exner (3); Sarah Gang (4); Morgan Brazil (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
-TRIGGER:-PT11H
+TRIGGER:-PT9H30M
 ACTION:DISPLAY
 DESCRIPTION:LTTA Tennis Match Reminder
 END:VALARM

--- a/teams/tuesday/ics/6/week9.ics
+++ b/teams/tuesday/ics/6/week9.ics
@@ -25,8 +25,7 @@ DTSTAMP:20260721T190000Z
 DTSTART;TZID=America/Chicago:20260721T190000
 DTEND;TZID=America/Chicago:20260721T203000
 SUMMARY:LTTA Tennis: vs Subs (Home)
-DESCRIPTION:LTTA Tennis match: 6 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 6 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/tuesday/ics/7/team.ics
+++ b/teams/tuesday/ics/7/team.ics
@@ -35,8 +35,7 @@ DTSTAMP:20260609T190000Z
 DTSTART;TZID=America/Chicago:20260609T190000
 DTEND;TZID=America/Chicago:20260609T203000
 SUMMARY:LTTA Tennis: vs Subs
-DESCRIPTION:LTTA Tennis match: 7 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 7 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -63,9 +62,9 @@ UID:ltta-tuesday-7-week5@couleeregiontennis.org
 DTSTAMP:20260623T173000Z
 DTSTART;TZID=America/Chicago:20260623T173000
 DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Bounce It
-DESCRIPTION:LTTA Tennis match: 7 vs Bounce It at Green Island Park - Courts 1–5\nOpponent Roster: Yubo Nian (1); Matt Diehl (2); Tom Dwyer (3); Mike Roscos (3); Sean O'Flaherty (3); Dan Skemp (3); Joe Kotnour Sr. (4); Ann Kotnour (5)
-LOCATION:Green Island Park - Courts 1–5
+SUMMARY:LTTA Tennis: vs Jetsetters
+DESCRIPTION:LTTA Tennis match: 7 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY
@@ -133,9 +132,9 @@ UID:ltta-tuesday-7-week10@couleeregiontennis.org
 DTSTAMP:20260728T173000Z
 DTSTART;TZID=America/Chicago:20260728T173000
 DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 7 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
-LOCATION:Green Island Park - Courts 6–9
+SUMMARY:LTTA Tennis: vs Bounce It
+DESCRIPTION:LTTA Tennis match: 7 vs Bounce It at Green Island Park - Courts 1–5\nOpponent Roster: Yubo Nian (1); Matt Diehl (2); Tom Dwyer (3); Mike Roscos (3); Sean O'Flaherty (3); Dan Skemp (3); Joe Kotnour Sr. (4); Ann Kotnour (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/7/week10.ics
+++ b/teams/tuesday/ics/7/week10.ics
@@ -24,9 +24,9 @@ UID:ltta-tuesday-7-week10@couleeregiontennis.org
 DTSTAMP:20260728T173000Z
 DTSTART;TZID=America/Chicago:20260728T173000
 DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Jetsetters (Home)
-DESCRIPTION:LTTA Tennis match: 7 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
-LOCATION:Green Island Park - Courts 6–9
+SUMMARY:LTTA Tennis: vs Bounce It (Away)
+DESCRIPTION:LTTA Tennis match: 7 vs Bounce It at Green Island Park - Courts 1–5\nOpponent Roster: Yubo Nian (1); Matt Diehl (2); Tom Dwyer (3); Mike Roscos (3); Sean O'Flaherty (3); Dan Skemp (3); Joe Kotnour Sr. (4); Ann Kotnour (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/7/week3.ics
+++ b/teams/tuesday/ics/7/week3.ics
@@ -25,8 +25,7 @@ DTSTAMP:20260609T190000Z
 DTSTART;TZID=America/Chicago:20260609T190000
 DTEND;TZID=America/Chicago:20260609T203000
 SUMMARY:LTTA Tennis: vs Subs (Away)
-DESCRIPTION:LTTA Tennis match: 7 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 7 vs Subs at Green Island Park - Courts 6–9\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/tuesday/ics/7/week5.ics
+++ b/teams/tuesday/ics/7/week5.ics
@@ -24,9 +24,9 @@ UID:ltta-tuesday-7-week5@couleeregiontennis.org
 DTSTAMP:20260623T173000Z
 DTSTART;TZID=America/Chicago:20260623T173000
 DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Bounce It (Away)
-DESCRIPTION:LTTA Tennis match: 7 vs Bounce It at Green Island Park - Courts 1–5\nOpponent Roster: Yubo Nian (1); Matt Diehl (2); Tom Dwyer (3); Mike Roscos (3); Sean O'Flaherty (3); Dan Skemp (3); Joe Kotnour Sr. (4); Ann Kotnour (5)
-LOCATION:Green Island Park - Courts 1–5
+SUMMARY:LTTA Tennis: vs Jetsetters (Home)
+DESCRIPTION:LTTA Tennis match: 7 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/8/team.ics
+++ b/teams/tuesday/ics/8/team.ics
@@ -49,7 +49,7 @@ DTSTAMP:20260616T190000Z
 DTSTART;TZID=America/Chicago:20260616T190000
 DTEND;TZID=America/Chicago:20260616T203000
 SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 8 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 8 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -62,9 +62,9 @@ UID:ltta-tuesday-8-week5@couleeregiontennis.org
 DTSTAMP:20260623T173000Z
 DTSTART;TZID=America/Chicago:20260623T173000
 DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Spin Doctors
-DESCRIPTION:LTTA Tennis match: 8 vs Spin Doctors at Green Island Park - Courts 6–9\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
-LOCATION:Green Island Park - Courts 6–9
+SUMMARY:LTTA Tennis: vs Bounce It
+DESCRIPTION:LTTA Tennis match: 8 vs Bounce It at Green Island Park - Courts 10–13\nOpponent Roster: Yubo Nian (1); Matt Diehl (2); Tom Dwyer (3); Mike Roscos (3); Sean O'Flaherty (3); Dan Skemp (3); Joe Kotnour Sr. (4); Ann Kotnour (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY
@@ -105,8 +105,7 @@ DTSTAMP:20260714T173000Z
 DTSTART;TZID=America/Chicago:20260714T173000
 DTEND;TZID=America/Chicago:20260714T190000
 SUMMARY:LTTA Tennis: vs Subs
-DESCRIPTION:LTTA Tennis match: 8 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 8 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -133,9 +132,9 @@ UID:ltta-tuesday-8-week10@couleeregiontennis.org
 DTSTAMP:20260728T173000Z
 DTSTART;TZID=America/Chicago:20260728T173000
 DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Bounce It
-DESCRIPTION:LTTA Tennis match: 8 vs Bounce It at Green Island Park - Courts 10–13\nOpponent Roster: Yubo Nian (1); Matt Diehl (2); Tom Dwyer (3); Mike Roscos (3); Sean O'Flaherty (3); Dan Skemp (3); Joe Kotnour Sr. (4); Ann Kotnour (5)
-LOCATION:Green Island Park - Courts 10–13
+SUMMARY:LTTA Tennis: vs Spin Doctors
+DESCRIPTION:LTTA Tennis match: 8 vs Spin Doctors at Green Island Park - Courts 6–9\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/8/week10.ics
+++ b/teams/tuesday/ics/8/week10.ics
@@ -24,9 +24,9 @@ UID:ltta-tuesday-8-week10@couleeregiontennis.org
 DTSTAMP:20260728T173000Z
 DTSTART;TZID=America/Chicago:20260728T173000
 DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Bounce It (Home)
-DESCRIPTION:LTTA Tennis match: 8 vs Bounce It at Green Island Park - Courts 10–13\nOpponent Roster: Yubo Nian (1); Matt Diehl (2); Tom Dwyer (3); Mike Roscos (3); Sean O'Flaherty (3); Dan Skemp (3); Joe Kotnour Sr. (4); Ann Kotnour (5)
-LOCATION:Green Island Park - Courts 10–13
+SUMMARY:LTTA Tennis: vs Spin Doctors (Home)
+DESCRIPTION:LTTA Tennis match: 8 vs Spin Doctors at Green Island Park - Courts 6–9\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
+LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/8/week4.ics
+++ b/teams/tuesday/ics/8/week4.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260616T190000Z
 DTSTART;TZID=America/Chicago:20260616T190000
 DTEND;TZID=America/Chicago:20260616T203000
 SUMMARY:LTTA Tennis: vs Jetsetters (Away)
-DESCRIPTION:LTTA Tennis match: 8 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 8 vs Jetsetters at Green Island Park - Courts 6–9\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/tuesday/ics/8/week5.ics
+++ b/teams/tuesday/ics/8/week5.ics
@@ -24,9 +24,9 @@ UID:ltta-tuesday-8-week5@couleeregiontennis.org
 DTSTAMP:20260623T173000Z
 DTSTART;TZID=America/Chicago:20260623T173000
 DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Spin Doctors (Home)
-DESCRIPTION:LTTA Tennis match: 8 vs Spin Doctors at Green Island Park - Courts 6–9\nOpponent Roster: Tung Ouy (1); Rich Puent (2); Sai Mathi (3); Isaac Puent (3); Molly Stenger (3); Leah Bower (3); Jim Brieske (4); Kalyan Satydeep (5)
-LOCATION:Green Island Park - Courts 6–9
+SUMMARY:LTTA Tennis: vs Bounce It (Home)
+DESCRIPTION:LTTA Tennis match: 8 vs Bounce It at Green Island Park - Courts 10–13\nOpponent Roster: Yubo Nian (1); Matt Diehl (2); Tom Dwyer (3); Mike Roscos (3); Sean O'Flaherty (3); Dan Skemp (3); Joe Kotnour Sr. (4); Ann Kotnour (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/8/week8.ics
+++ b/teams/tuesday/ics/8/week8.ics
@@ -25,8 +25,7 @@ DTSTAMP:20260714T173000Z
 DTSTART;TZID=America/Chicago:20260714T173000
 DTEND;TZID=America/Chicago:20260714T190000
 SUMMARY:LTTA Tennis: vs Subs (Home)
-DESCRIPTION:LTTA Tennis match: 8 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 8 vs Subs at Green Island Park - Courts 1–5\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/tuesday/ics/9/team.ics
+++ b/teams/tuesday/ics/9/team.ics
@@ -21,8 +21,7 @@ DTSTAMP:20260602T173000Z
 DTSTART;TZID=America/Chicago:20260602T173000
 DTEND;TZID=America/Chicago:20260602T190000
 SUMMARY:LTTA Tennis: vs Subs
-DESCRIPTION:LTTA Tennis match: 9 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 9 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -63,9 +62,9 @@ UID:ltta-tuesday-9-week5@couleeregiontennis.org
 DTSTAMP:20260623T173000Z
 DTSTART;TZID=America/Chicago:20260623T173000
 DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Good Ol' Boys
-DESCRIPTION:LTTA Tennis match: 9 vs Good Ol' Boys at Green Island Park - Courts 1–5\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
-LOCATION:Green Island Park - Courts 1–5
+SUMMARY:LTTA Tennis: vs Return to Sender with Love
+DESCRIPTION:LTTA Tennis match: 9 vs Return to Sender with Love at Green Island Park - Courts 10–13\nOpponent Roster: Denny Kreuser (1); Paul Leithold (2); Sara Bieneman (3); Missy Marcus (3); Julie Kamla (3); Asher Helgerson (3); Catherine Roraff (4); Mary Leithold (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY
@@ -120,7 +119,7 @@ DTSTAMP:20260721T190000Z
 DTSTART;TZID=America/Chicago:20260721T190000
 DTEND;TZID=America/Chicago:20260721T203000
 SUMMARY:LTTA Tennis: vs Jetsetters
-DESCRIPTION:LTTA Tennis match: 9 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 9 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -133,9 +132,9 @@ UID:ltta-tuesday-9-week10@couleeregiontennis.org
 DTSTAMP:20260728T173000Z
 DTSTART;TZID=America/Chicago:20260728T173000
 DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Return to Sender with Love
-DESCRIPTION:LTTA Tennis match: 9 vs Return to Sender with Love at Green Island Park - Courts 10–13\nOpponent Roster: Denny Kreuser (1); Paul Leithold (2); Sara Bieneman (3); Missy Marcus (3); Julie Kamla (3); Asher Helgerson (3); Catherine Roraff (4); Mary Leithold (5)
-LOCATION:Green Island Park - Courts 10–13
+SUMMARY:LTTA Tennis: vs Good Ol' Boys
+DESCRIPTION:LTTA Tennis match: 9 vs Good Ol' Boys at Green Island Park - Courts 1–5\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/9/week10.ics
+++ b/teams/tuesday/ics/9/week10.ics
@@ -24,9 +24,9 @@ UID:ltta-tuesday-9-week10@couleeregiontennis.org
 DTSTAMP:20260728T173000Z
 DTSTART;TZID=America/Chicago:20260728T173000
 DTEND;TZID=America/Chicago:20260728T190000
-SUMMARY:LTTA Tennis: vs Return to Sender with Love (Away)
-DESCRIPTION:LTTA Tennis match: 9 vs Return to Sender with Love at Green Island Park - Courts 10–13\nOpponent Roster: Denny Kreuser (1); Paul Leithold (2); Sara Bieneman (3); Missy Marcus (3); Julie Kamla (3); Asher Helgerson (3); Catherine Roraff (4); Mary Leithold (5)
-LOCATION:Green Island Park - Courts 10–13
+SUMMARY:LTTA Tennis: vs Good Ol' Boys (Home)
+DESCRIPTION:LTTA Tennis match: 9 vs Good Ol' Boys at Green Island Park - Courts 1–5\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
+LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/9/week2.ics
+++ b/teams/tuesday/ics/9/week2.ics
@@ -25,8 +25,7 @@ DTSTAMP:20260602T173000Z
 DTSTART;TZID=America/Chicago:20260602T173000
 DTEND;TZID=America/Chicago:20260602T190000
 SUMMARY:LTTA Tennis: vs Subs (Home)
-DESCRIPTION:LTTA Tennis match: 9 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson                       
-Kirk Arneson                kirk.arneson@gmail.com        608 397 4536 (3); Kirk Arneson (3); Raj Remnarace (3); Laura Prosperi (5)
+DESCRIPTION:LTTA Tennis match: 9 vs Subs at Green Island Park - Courts 10–13\nOpponent Roster: Sawyer Kuck (1); Dave Wissink (2); Dave Mills (3); Amanda Arneson (3); Kirk Arneson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/tuesday/ics/9/week5.ics
+++ b/teams/tuesday/ics/9/week5.ics
@@ -24,9 +24,9 @@ UID:ltta-tuesday-9-week5@couleeregiontennis.org
 DTSTAMP:20260623T173000Z
 DTSTART;TZID=America/Chicago:20260623T173000
 DTEND;TZID=America/Chicago:20260623T190000
-SUMMARY:LTTA Tennis: vs Good Ol' Boys (Home)
-DESCRIPTION:LTTA Tennis match: 9 vs Good Ol' Boys at Green Island Park - Courts 1–5\nOpponent Roster: Paul Jacobson (1); Brennan Quinn (2); Don Harvey (3); David Lange (3); Larry Ruff (3); Cory Ruud (3); Pennie Pierce-Jorgeson (4); Sally Ruud (5)
-LOCATION:Green Island Park - Courts 1–5
+SUMMARY:LTTA Tennis: vs Return to Sender with Love (Away)
+DESCRIPTION:LTTA Tennis match: 9 vs Return to Sender with Love at Green Island Park - Courts 10–13\nOpponent Roster: Denny Kreuser (1); Paul Leithold (2); Sara Bieneman (3); Missy Marcus (3); Julie Kamla (3); Asher Helgerson (3); Catherine Roraff (4); Mary Leithold (5)
+LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M
 ACTION:DISPLAY

--- a/teams/tuesday/ics/9/week9.ics
+++ b/teams/tuesday/ics/9/week9.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260721T190000Z
 DTSTART;TZID=America/Chicago:20260721T190000
 DTEND;TZID=America/Chicago:20260721T203000
 SUMMARY:LTTA Tennis: vs Jetsetters (Home)
-DESCRIPTION:LTTA Tennis match: 9 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Jada Brunkow (3); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3); Aaron Olson (4); Anna Olson (5)
+DESCRIPTION:LTTA Tennis match: 9 vs Jetsetters at Green Island Park - Courts 10–13\nOpponent Roster: Drake Wonderling (1); Corey Stauner (2); Dan Petersen (3); Shirley Yuan (3); Tyler Benson (3)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/tuesday/schedules/1.json
+++ b/teams/tuesday/schedules/1.json
@@ -57,13 +57,13 @@
     {
       "week": 5,
       "date": "2026-06-23",
-      "time": "5:30pm",
-      "courts": "Courts 6–9",
+      "time": "7:00pm",
+      "courts": "Courts 10–13",
       "homeAway": "Away",
       "opponent": {
-        "name": "Return to Sender with Love",
-        "number": "8",
-        "file": "/pages/team.html?day=tuesday&team=8"
+        "name": "Herons",
+        "number": "3",
+        "file": "/pages/team.html?day=tuesday&team=3"
       },
       "ics": "/teams/tuesday/ics/1/week5.ics"
     },
@@ -122,13 +122,13 @@
     {
       "week": 10,
       "date": "2026-07-28",
-      "time": "7:00pm",
-      "courts": "Courts 10–13",
+      "time": "5:30pm",
+      "courts": "Courts 6–9",
       "homeAway": "Away",
       "opponent": {
-        "name": "Herons",
-        "number": "3",
-        "file": "/pages/team.html?day=tuesday&team=3"
+        "name": "Return to Sender with Love",
+        "number": "8",
+        "file": "/pages/team.html?day=tuesday&team=8"
       },
       "ics": "/teams/tuesday/ics/1/week10.ics"
     },

--- a/teams/tuesday/schedules/10.json
+++ b/teams/tuesday/schedules/10.json
@@ -57,13 +57,13 @@
     {
       "week": 5,
       "date": "2026-06-23",
-      "time": "7:00pm",
-      "courts": "Courts 1–5",
-      "homeAway": "Home",
+      "time": "5:30pm",
+      "courts": "Courts 6–9",
+      "homeAway": "Away",
       "opponent": {
-        "name": "Rascals",
-        "number": "6",
-        "file": "/pages/team.html?day=tuesday&team=6"
+        "name": "Good Ol' Boys",
+        "number": "7",
+        "file": "/pages/team.html?day=tuesday&team=7"
       },
       "ics": "/teams/tuesday/ics/10/week5.ics"
     },
@@ -122,13 +122,13 @@
     {
       "week": 10,
       "date": "2026-07-28",
-      "time": "5:30pm",
-      "courts": "Courts 6–9",
-      "homeAway": "Away",
+      "time": "7:00pm",
+      "courts": "Courts 1–5",
+      "homeAway": "Home",
       "opponent": {
-        "name": "Good Ol' Boys",
-        "number": "7",
-        "file": "/pages/team.html?day=tuesday&team=7"
+        "name": "Rascals",
+        "number": "6",
+        "file": "/pages/team.html?day=tuesday&team=6"
       },
       "ics": "/teams/tuesday/ics/10/week10.ics"
     },

--- a/teams/tuesday/schedules/11.json
+++ b/teams/tuesday/schedules/11.json
@@ -57,13 +57,13 @@
     {
       "week": 5,
       "date": "2026-06-23",
-      "time": "7:00pm",
-      "courts": "Courts 6–9",
-      "homeAway": "Home",
+      "time": "5:30pm",
+      "courts": "Courts 1–5",
+      "homeAway": "Away",
       "opponent": {
-        "name": "Racquet Scientists",
-        "number": "5",
-        "file": "/pages/team.html?day=tuesday&team=5"
+        "name": "Rascals",
+        "number": "6",
+        "file": "/pages/team.html?day=tuesday&team=6"
       },
       "ics": "/teams/tuesday/ics/11/week5.ics"
     },
@@ -122,13 +122,13 @@
     {
       "week": 10,
       "date": "2026-07-28",
-      "time": "5:30pm",
-      "courts": "Courts 1–5",
-      "homeAway": "Away",
+      "time": "7:00pm",
+      "courts": "Courts 6–9",
+      "homeAway": "Home",
       "opponent": {
-        "name": "Rascals",
-        "number": "6",
-        "file": "/pages/team.html?day=tuesday&team=6"
+        "name": "Racquet Scientists",
+        "number": "5",
+        "file": "/pages/team.html?day=tuesday&team=5"
       },
       "ics": "/teams/tuesday/ics/11/week10.ics"
     },

--- a/teams/tuesday/schedules/12.json
+++ b/teams/tuesday/schedules/12.json
@@ -58,12 +58,12 @@
       "week": 5,
       "date": "2026-06-23",
       "time": "7:00pm",
-      "courts": "Courts 10–13",
-      "homeAway": "Home",
+      "courts": "Courts 1–5",
+      "homeAway": "Away",
       "opponent": {
-        "name": "Approach Shots",
-        "number": "4",
-        "file": "/pages/team.html?day=tuesday&team=4"
+        "name": "Racquet Scientists",
+        "number": "5",
+        "file": "/pages/team.html?day=tuesday&team=5"
       },
       "ics": "/teams/tuesday/ics/12/week5.ics"
     },
@@ -123,12 +123,12 @@
       "week": 10,
       "date": "2026-07-28",
       "time": "7:00pm",
-      "courts": "Courts 1–5",
-      "homeAway": "Away",
+      "courts": "Courts 10–13",
+      "homeAway": "Home",
       "opponent": {
-        "name": "Racquet Scientists",
-        "number": "5",
-        "file": "/pages/team.html?day=tuesday&team=5"
+        "name": "Approach Shots",
+        "number": "4",
+        "file": "/pages/team.html?day=tuesday&team=4"
       },
       "ics": "/teams/tuesday/ics/12/week10.ics"
     },

--- a/teams/tuesday/schedules/2.json
+++ b/teams/tuesday/schedules/2.json
@@ -57,13 +57,13 @@
     {
       "week": 5,
       "date": "2026-06-23",
-      "time": "5:30pm",
-      "courts": "Courts 10–13",
-      "homeAway": "Home",
+      "time": "7:00pm",
+      "courts": "Courts 6–9",
+      "homeAway": "Away",
       "opponent": {
-        "name": "Herons",
-        "number": "3",
-        "file": "/pages/team.html?day=tuesday&team=3"
+        "name": "Approach Shots",
+        "number": "4",
+        "file": "/pages/team.html?day=tuesday&team=4"
       },
       "ics": "/teams/tuesday/ics/2/week5.ics"
     },
@@ -122,13 +122,13 @@
     {
       "week": 10,
       "date": "2026-07-28",
-      "time": "7:00pm",
-      "courts": "Courts 6–9",
-      "homeAway": "Away",
+      "time": "5:30pm",
+      "courts": "Courts 10–13",
+      "homeAway": "Home",
       "opponent": {
-        "name": "Approach Shots",
-        "number": "4",
-        "file": "/pages/team.html?day=tuesday&team=4"
+        "name": "Herons",
+        "number": "3",
+        "file": "/pages/team.html?day=tuesday&team=3"
       },
       "ics": "/teams/tuesday/ics/2/week10.ics"
     },

--- a/teams/tuesday/schedules/3.json
+++ b/teams/tuesday/schedules/3.json
@@ -57,13 +57,13 @@
     {
       "week": 5,
       "date": "2026-06-23",
-      "time": "5:30pm",
+      "time": "7:00pm",
       "courts": "Courts 10–13",
-      "homeAway": "Away",
+      "homeAway": "Home",
       "opponent": {
-        "name": "Subs",
-        "number": "2",
-        "file": "/pages/team.html?day=tuesday&team=2"
+        "name": "Spin Doctors",
+        "number": "1",
+        "file": "/pages/team.html?day=tuesday&team=1"
       },
       "ics": "/teams/tuesday/ics/3/week5.ics"
     },
@@ -122,13 +122,13 @@
     {
       "week": 10,
       "date": "2026-07-28",
-      "time": "7:00pm",
+      "time": "5:30pm",
       "courts": "Courts 10–13",
-      "homeAway": "Home",
+      "homeAway": "Away",
       "opponent": {
-        "name": "Spin Doctors",
-        "number": "1",
-        "file": "/pages/team.html?day=tuesday&team=1"
+        "name": "Subs",
+        "number": "2",
+        "file": "/pages/team.html?day=tuesday&team=2"
       },
       "ics": "/teams/tuesday/ics/3/week10.ics"
     },

--- a/teams/tuesday/schedules/4.json
+++ b/teams/tuesday/schedules/4.json
@@ -58,12 +58,12 @@
       "week": 5,
       "date": "2026-06-23",
       "time": "7:00pm",
-      "courts": "Courts 10–13",
-      "homeAway": "Away",
+      "courts": "Courts 6–9",
+      "homeAway": "Home",
       "opponent": {
-        "name": "Easy Overhead",
-        "number": "12",
-        "file": "/pages/team.html?day=tuesday&team=12"
+        "name": "Subs",
+        "number": "2",
+        "file": "/pages/team.html?day=tuesday&team=2"
       },
       "ics": "/teams/tuesday/ics/4/week5.ics"
     },
@@ -123,12 +123,12 @@
       "week": 10,
       "date": "2026-07-28",
       "time": "7:00pm",
-      "courts": "Courts 6–9",
-      "homeAway": "Home",
+      "courts": "Courts 10–13",
+      "homeAway": "Away",
       "opponent": {
-        "name": "Subs",
-        "number": "2",
-        "file": "/pages/team.html?day=tuesday&team=2"
+        "name": "Easy Overhead",
+        "number": "12",
+        "file": "/pages/team.html?day=tuesday&team=12"
       },
       "ics": "/teams/tuesday/ics/4/week10.ics"
     },

--- a/teams/tuesday/schedules/5.json
+++ b/teams/tuesday/schedules/5.json
@@ -58,12 +58,12 @@
       "week": 5,
       "date": "2026-06-23",
       "time": "7:00pm",
-      "courts": "Courts 6–9",
-      "homeAway": "Away",
+      "courts": "Courts 1–5",
+      "homeAway": "Home",
       "opponent": {
-        "name": "Full Metal Racquet",
-        "number": "11",
-        "file": "/pages/team.html?day=tuesday&team=11"
+        "name": "Easy Overhead",
+        "number": "12",
+        "file": "/pages/team.html?day=tuesday&team=12"
       },
       "ics": "/teams/tuesday/ics/5/week5.ics"
     },
@@ -123,12 +123,12 @@
       "week": 10,
       "date": "2026-07-28",
       "time": "7:00pm",
-      "courts": "Courts 1–5",
-      "homeAway": "Home",
+      "courts": "Courts 6–9",
+      "homeAway": "Away",
       "opponent": {
-        "name": "Easy Overhead",
-        "number": "12",
-        "file": "/pages/team.html?day=tuesday&team=12"
+        "name": "Full Metal Racquet",
+        "number": "11",
+        "file": "/pages/team.html?day=tuesday&team=11"
       },
       "ics": "/teams/tuesday/ics/5/week10.ics"
     },

--- a/teams/tuesday/schedules/6.json
+++ b/teams/tuesday/schedules/6.json
@@ -57,13 +57,13 @@
     {
       "week": 5,
       "date": "2026-06-23",
-      "time": "7:00pm",
+      "time": "5:30pm",
       "courts": "Courts 1–5",
-      "homeAway": "Away",
+      "homeAway": "Home",
       "opponent": {
-        "name": "Jetsetters",
-        "number": "10",
-        "file": "/pages/team.html?day=tuesday&team=10"
+        "name": "Full Metal Racquet",
+        "number": "11",
+        "file": "/pages/team.html?day=tuesday&team=11"
       },
       "ics": "/teams/tuesday/ics/6/week5.ics"
     },
@@ -122,13 +122,13 @@
     {
       "week": 10,
       "date": "2026-07-28",
-      "time": "5:30pm",
+      "time": "7:00pm",
       "courts": "Courts 1–5",
-      "homeAway": "Home",
+      "homeAway": "Away",
       "opponent": {
-        "name": "Full Metal Racquet",
-        "number": "11",
-        "file": "/pages/team.html?day=tuesday&team=11"
+        "name": "Jetsetters",
+        "number": "10",
+        "file": "/pages/team.html?day=tuesday&team=10"
       },
       "ics": "/teams/tuesday/ics/6/week10.ics"
     },

--- a/teams/tuesday/schedules/7.json
+++ b/teams/tuesday/schedules/7.json
@@ -58,12 +58,12 @@
       "week": 5,
       "date": "2026-06-23",
       "time": "5:30pm",
-      "courts": "Courts 1–5",
-      "homeAway": "Away",
+      "courts": "Courts 6–9",
+      "homeAway": "Home",
       "opponent": {
-        "name": "Bounce It",
-        "number": "9",
-        "file": "/pages/team.html?day=tuesday&team=9"
+        "name": "Jetsetters",
+        "number": "10",
+        "file": "/pages/team.html?day=tuesday&team=10"
       },
       "ics": "/teams/tuesday/ics/7/week5.ics"
     },
@@ -123,12 +123,12 @@
       "week": 10,
       "date": "2026-07-28",
       "time": "5:30pm",
-      "courts": "Courts 6–9",
-      "homeAway": "Home",
+      "courts": "Courts 1–5",
+      "homeAway": "Away",
       "opponent": {
-        "name": "Jetsetters",
-        "number": "10",
-        "file": "/pages/team.html?day=tuesday&team=10"
+        "name": "Bounce It",
+        "number": "9",
+        "file": "/pages/team.html?day=tuesday&team=9"
       },
       "ics": "/teams/tuesday/ics/7/week10.ics"
     },

--- a/teams/tuesday/schedules/8.json
+++ b/teams/tuesday/schedules/8.json
@@ -58,12 +58,12 @@
       "week": 5,
       "date": "2026-06-23",
       "time": "5:30pm",
-      "courts": "Courts 6–9",
+      "courts": "Courts 10–13",
       "homeAway": "Home",
       "opponent": {
-        "name": "Spin Doctors",
-        "number": "1",
-        "file": "/pages/team.html?day=tuesday&team=1"
+        "name": "Bounce It",
+        "number": "9",
+        "file": "/pages/team.html?day=tuesday&team=9"
       },
       "ics": "/teams/tuesday/ics/8/week5.ics"
     },
@@ -123,12 +123,12 @@
       "week": 10,
       "date": "2026-07-28",
       "time": "5:30pm",
-      "courts": "Courts 10–13",
+      "courts": "Courts 6–9",
       "homeAway": "Home",
       "opponent": {
-        "name": "Bounce It",
-        "number": "9",
-        "file": "/pages/team.html?day=tuesday&team=9"
+        "name": "Spin Doctors",
+        "number": "1",
+        "file": "/pages/team.html?day=tuesday&team=1"
       },
       "ics": "/teams/tuesday/ics/8/week10.ics"
     },

--- a/teams/tuesday/schedules/9.json
+++ b/teams/tuesday/schedules/9.json
@@ -58,12 +58,12 @@
       "week": 5,
       "date": "2026-06-23",
       "time": "5:30pm",
-      "courts": "Courts 1–5",
-      "homeAway": "Home",
+      "courts": "Courts 10–13",
+      "homeAway": "Away",
       "opponent": {
-        "name": "Good Ol' Boys",
-        "number": "7",
-        "file": "/pages/team.html?day=tuesday&team=7"
+        "name": "Return to Sender with Love",
+        "number": "8",
+        "file": "/pages/team.html?day=tuesday&team=8"
       },
       "ics": "/teams/tuesday/ics/9/week5.ics"
     },
@@ -123,12 +123,12 @@
       "week": 10,
       "date": "2026-07-28",
       "time": "5:30pm",
-      "courts": "Courts 10–13",
-      "homeAway": "Away",
+      "courts": "Courts 1–5",
+      "homeAway": "Home",
       "opponent": {
-        "name": "Return to Sender with Love",
-        "number": "8",
-        "file": "/pages/team.html?day=tuesday&team=8"
+        "name": "Good Ol' Boys",
+        "number": "7",
+        "file": "/pages/team.html?day=tuesday&team=7"
       },
       "ics": "/teams/tuesday/ics/9/week10.ics"
     },

--- a/teams/tuesday/schedules/master_schedule.json
+++ b/teams/tuesday/schedules/master_schedule.json
@@ -338,11 +338,11 @@
   {
     "week": 5,
     "date": "2026-06-23",
-    "time": "5:30pm",
-    "courts": "Courts 6–9",
+    "time": "7:00pm",
+    "courts": "Courts 10–13",
     "teamA": {
-      "number": "8",
-      "name": "Return to Sender with Love"
+      "number": "3",
+      "name": "Herons"
     },
     "teamB": {
       "number": "1",
@@ -352,15 +352,15 @@
   {
     "week": 5,
     "date": "2026-06-23",
-    "time": "5:30pm",
-    "courts": "Courts 1–5",
+    "time": "7:00pm",
+    "courts": "Courts 6–9",
     "teamA": {
-      "number": "9",
-      "name": "Bounce It"
+      "number": "4",
+      "name": "Approach Shots"
     },
     "teamB": {
-      "number": "7",
-      "name": "Good Ol' Boys"
+      "number": "2",
+      "name": "Subs"
     }
   },
   {
@@ -369,54 +369,54 @@
     "time": "7:00pm",
     "courts": "Courts 1–5",
     "teamA": {
-      "number": "10",
-      "name": "Jetsetters"
-    },
-    "teamB": {
-      "number": "6",
-      "name": "Rascals"
-    }
-  },
-  {
-    "week": 5,
-    "date": "2026-06-23",
-    "time": "7:00pm",
-    "courts": "Courts 6–9",
-    "teamA": {
-      "number": "11",
-      "name": "Full Metal Racquet"
-    },
-    "teamB": {
       "number": "5",
       "name": "Racquet Scientists"
-    }
-  },
-  {
-    "week": 5,
-    "date": "2026-06-23",
-    "time": "7:00pm",
-    "courts": "Courts 10–13",
-    "teamA": {
-      "number": "12",
-      "name": "Easy Overhead"
     },
     "teamB": {
-      "number": "4",
-      "name": "Approach Shots"
+      "number": "12",
+      "name": "Easy Overhead"
     }
   },
   {
     "week": 5,
     "date": "2026-06-23",
     "time": "5:30pm",
-    "courts": "Courts 10–13",
+    "courts": "Courts 1–5",
     "teamA": {
-      "number": "2",
-      "name": "Subs"
+      "number": "6",
+      "name": "Rascals"
     },
     "teamB": {
-      "number": "3",
-      "name": "Herons"
+      "number": "11",
+      "name": "Full Metal Racquet"
+    }
+  },
+  {
+    "week": 5,
+    "date": "2026-06-23",
+    "time": "5:30pm",
+    "courts": "Courts 6–9",
+    "teamA": {
+      "number": "7",
+      "name": "Good Ol' Boys"
+    },
+    "teamB": {
+      "number": "10",
+      "name": "Jetsetters"
+    }
+  },
+  {
+    "week": 5,
+    "date": "2026-06-23",
+    "time": "5:30pm",
+    "courts": "Courts 10–13",
+    "teamA": {
+      "number": "8",
+      "name": "Return to Sender with Love"
+    },
+    "teamB": {
+      "number": "9",
+      "name": "Bounce It"
     }
   },
   {
@@ -758,11 +758,11 @@
   {
     "week": 10,
     "date": "2026-07-28",
-    "time": "7:00pm",
-    "courts": "Courts 10–13",
+    "time": "5:30pm",
+    "courts": "Courts 6–9",
     "teamA": {
-      "number": "3",
-      "name": "Herons"
+      "number": "8",
+      "name": "Return to Sender with Love"
     },
     "teamB": {
       "number": "1",
@@ -772,57 +772,57 @@
   {
     "week": 10,
     "date": "2026-07-28",
-    "time": "7:00pm",
-    "courts": "Courts 6–9",
-    "teamA": {
-      "number": "4",
-      "name": "Approach Shots"
-    },
-    "teamB": {
-      "number": "2",
-      "name": "Subs"
-    }
-  },
-  {
-    "week": 10,
-    "date": "2026-07-28",
-    "time": "7:00pm",
-    "courts": "Courts 1–5",
-    "teamA": {
-      "number": "5",
-      "name": "Racquet Scientists"
-    },
-    "teamB": {
-      "number": "12",
-      "name": "Easy Overhead"
-    }
-  },
-  {
-    "week": 10,
-    "date": "2026-07-28",
     "time": "5:30pm",
     "courts": "Courts 1–5",
     "teamA": {
-      "number": "6",
-      "name": "Rascals"
+      "number": "9",
+      "name": "Bounce It"
     },
     "teamB": {
-      "number": "11",
-      "name": "Full Metal Racquet"
-    }
-  },
-  {
-    "week": 10,
-    "date": "2026-07-28",
-    "time": "5:30pm",
-    "courts": "Courts 6–9",
-    "teamA": {
       "number": "7",
       "name": "Good Ol' Boys"
-    },
-    "teamB": {
+    }
+  },
+  {
+    "week": 10,
+    "date": "2026-07-28",
+    "time": "7:00pm",
+    "courts": "Courts 1–5",
+    "teamA": {
       "number": "10",
       "name": "Jetsetters"
+    },
+    "teamB": {
+      "number": "6",
+      "name": "Rascals"
+    }
+  },
+  {
+    "week": 10,
+    "date": "2026-07-28",
+    "time": "7:00pm",
+    "courts": "Courts 6–9",
+    "teamA": {
+      "number": "11",
+      "name": "Full Metal Racquet"
+    },
+    "teamB": {
+      "number": "5",
+      "name": "Racquet Scientists"
+    }
+  },
+  {
+    "week": 10,
+    "date": "2026-07-28",
+    "time": "7:00pm",
+    "courts": "Courts 10–13",
+    "teamA": {
+      "number": "12",
+      "name": "Easy Overhead"
+    },
+    "teamB": {
+      "number": "4",
+      "name": "Approach Shots"
     }
   },
   {
@@ -831,12 +831,12 @@
     "time": "5:30pm",
     "courts": "Courts 10–13",
     "teamA": {
-      "number": "8",
-      "name": "Return to Sender with Love"
+      "number": "2",
+      "name": "Subs"
     },
     "teamB": {
-      "number": "9",
-      "name": "Bounce It"
+      "number": "3",
+      "name": "Herons"
     }
   },
   {

--- a/teams/wednesday/all.html
+++ b/teams/wednesday/all.html
@@ -320,6 +320,6 @@
         <td class="match-cell"><span class="team-num">5</span>Glory Days (h) vs <span class="team-num">10</span>Backhand Bandits<br><small style="color: #666; font-weight: bold;">(Green Island)</small><br></td>
       </tr>
     </table>
-    <p style="text-align:center; font-size: 0.8em; color: #999;">Last Updated: 5/23/2026, 1:39:49 PM</p>
+    <p style="text-align:center; font-size: 0.8em; color: #999;">Last Updated: 6/21/2026, 7:10:07 AM</p>
   </body>
 </html>

--- a/teams/wednesday/ics/1/team.ics
+++ b/teams/wednesday/ics/1/team.ics
@@ -119,7 +119,7 @@ DTSTAMP:20260722T173000Z
 DTSTART;TZID=America/Chicago:20260722T173000
 DTEND;TZID=America/Chicago:20260722T190000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 1 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 1 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -147,7 +147,7 @@ DTSTAMP:20260805T173000Z
 DTSTART;TZID=America/Chicago:20260805T173000
 DTEND;TZID=America/Chicago:20260805T190000
 SUMMARY:LTTA Tennis: vs Rally Monkeys
-DESCRIPTION:LTTA Tennis match: 1 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 1 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/1/week11.ics
+++ b/teams/wednesday/ics/1/week11.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260805T173000Z
 DTSTART;TZID=America/Chicago:20260805T173000
 DTEND;TZID=America/Chicago:20260805T190000
 SUMMARY:LTTA Tennis: vs Rally Monkeys (Home)
-DESCRIPTION:LTTA Tennis match: 1 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 1 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/1/week9.ics
+++ b/teams/wednesday/ics/1/week9.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260722T173000Z
 DTSTART;TZID=America/Chicago:20260722T173000
 DTEND;TZID=America/Chicago:20260722T190000
 SUMMARY:LTTA Tennis: vs Hot Shots (Home)
-DESCRIPTION:LTTA Tennis match: 1 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 1 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/10/team.ics
+++ b/teams/wednesday/ics/10/team.ics
@@ -77,7 +77,7 @@ DTSTAMP:20260701T173000Z
 DTSTART;TZID=America/Chicago:20260701T173000
 DTEND;TZID=America/Chicago:20260701T190000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 10 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 10 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -91,7 +91,7 @@ DTSTAMP:20260708T173000Z
 DTSTART;TZID=America/Chicago:20260708T173000
 DTEND;TZID=America/Chicago:20260708T190000
 SUMMARY:LTTA Tennis: vs Rally Monkeys
-DESCRIPTION:LTTA Tennis match: 10 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 10 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/10/week6.ics
+++ b/teams/wednesday/ics/10/week6.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260701T173000Z
 DTSTART;TZID=America/Chicago:20260701T173000
 DTEND;TZID=America/Chicago:20260701T190000
 SUMMARY:LTTA Tennis: vs Hot Shots (Away)
-DESCRIPTION:LTTA Tennis match: 10 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 10 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/10/week7.ics
+++ b/teams/wednesday/ics/10/week7.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260708T173000Z
 DTSTART;TZID=America/Chicago:20260708T173000
 DTEND;TZID=America/Chicago:20260708T190000
 SUMMARY:LTTA Tennis: vs Rally Monkeys (Home)
-DESCRIPTION:LTTA Tennis match: 10 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 10 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/11/team.ics
+++ b/teams/wednesday/ics/11/team.ics
@@ -7,7 +7,7 @@ DTSTAMP:20260527T190000Z
 DTSTART;TZID=America/Chicago:20260527T190000
 DTEND;TZID=America/Chicago:20260527T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys
-DESCRIPTION:LTTA Tennis match: 11 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 11 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -147,7 +147,7 @@ DTSTAMP:20260805T173000Z
 DTSTART;TZID=America/Chicago:20260805T173000
 DTEND;TZID=America/Chicago:20260805T190000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 11 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 11 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/11/week1.ics
+++ b/teams/wednesday/ics/11/week1.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260527T190000Z
 DTSTART;TZID=America/Chicago:20260527T190000
 DTEND;TZID=America/Chicago:20260527T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys (Away)
-DESCRIPTION:LTTA Tennis match: 11 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 11 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/11/week11.ics
+++ b/teams/wednesday/ics/11/week11.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260805T173000Z
 DTSTART;TZID=America/Chicago:20260805T173000
 DTEND;TZID=America/Chicago:20260805T190000
 SUMMARY:LTTA Tennis: vs Hot Shots (Away)
-DESCRIPTION:LTTA Tennis match: 11 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 11 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/12/team.ics
+++ b/teams/wednesday/ics/12/team.ics
@@ -63,7 +63,7 @@ DTSTAMP:20260624T190000Z
 DTSTART;TZID=America/Chicago:20260624T190000
 DTEND;TZID=America/Chicago:20260624T203000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 12 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 12 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -77,7 +77,7 @@ DTSTAMP:20260701T190000Z
 DTSTART;TZID=America/Chicago:20260701T190000
 DTEND;TZID=America/Chicago:20260701T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys
-DESCRIPTION:LTTA Tennis match: 12 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 12 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/12/week5.ics
+++ b/teams/wednesday/ics/12/week5.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260624T190000Z
 DTSTART;TZID=America/Chicago:20260624T190000
 DTEND;TZID=America/Chicago:20260624T203000
 SUMMARY:LTTA Tennis: vs Hot Shots (Home)
-DESCRIPTION:LTTA Tennis match: 12 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 12 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/12/week6.ics
+++ b/teams/wednesday/ics/12/week6.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260701T190000Z
 DTSTART;TZID=America/Chicago:20260701T190000
 DTEND;TZID=America/Chicago:20260701T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys (Home)
-DESCRIPTION:LTTA Tennis match: 12 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 12 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/2/team.ics
+++ b/teams/wednesday/ics/2/team.ics
@@ -133,7 +133,7 @@ DTSTAMP:20260729T190000Z
 DTSTART;TZID=America/Chicago:20260729T190000
 DTEND;TZID=America/Chicago:20260729T203000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 2 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 2 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/2/week10.ics
+++ b/teams/wednesday/ics/2/week10.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260729T190000Z
 DTSTART;TZID=America/Chicago:20260729T190000
 DTEND;TZID=America/Chicago:20260729T203000
 SUMMARY:LTTA Tennis: vs Hot Shots (Away)
-DESCRIPTION:LTTA Tennis match: 2 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 2 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/3/team.ics
+++ b/teams/wednesday/ics/3/team.ics
@@ -49,7 +49,7 @@ DTSTAMP:20260617T173000Z
 DTSTART;TZID=America/Chicago:20260617T173000
 DTEND;TZID=America/Chicago:20260617T190000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 3 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 3 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -63,7 +63,7 @@ DTSTAMP:20260624T173000Z
 DTSTART;TZID=America/Chicago:20260624T173000
 DTEND;TZID=America/Chicago:20260624T190000
 SUMMARY:LTTA Tennis: vs Rally Monkeys
-DESCRIPTION:LTTA Tennis match: 3 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 3 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/3/week4.ics
+++ b/teams/wednesday/ics/3/week4.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260617T173000Z
 DTSTART;TZID=America/Chicago:20260617T173000
 DTEND;TZID=America/Chicago:20260617T190000
 SUMMARY:LTTA Tennis: vs Hot Shots (Home)
-DESCRIPTION:LTTA Tennis match: 3 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 3 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/3/week5.ics
+++ b/teams/wednesday/ics/3/week5.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260624T173000Z
 DTSTART;TZID=America/Chicago:20260624T173000
 DTEND;TZID=America/Chicago:20260624T190000
 SUMMARY:LTTA Tennis: vs Rally Monkeys (Away)
-DESCRIPTION:LTTA Tennis match: 3 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 3 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/4/team.ics
+++ b/teams/wednesday/ics/4/team.ics
@@ -133,7 +133,7 @@ DTSTAMP:20260729T190000Z
 DTSTART;TZID=America/Chicago:20260729T190000
 DTEND;TZID=America/Chicago:20260729T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys
-DESCRIPTION:LTTA Tennis match: 4 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 4 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/4/week10.ics
+++ b/teams/wednesday/ics/4/week10.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260729T190000Z
 DTSTART;TZID=America/Chicago:20260729T190000
 DTEND;TZID=America/Chicago:20260729T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys (Home)
-DESCRIPTION:LTTA Tennis match: 4 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 4 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/5/team.ics
+++ b/teams/wednesday/ics/5/team.ics
@@ -35,7 +35,7 @@ DTSTAMP:20260610T190000Z
 DTSTART;TZID=America/Chicago:20260610T190000
 DTEND;TZID=America/Chicago:20260610T203000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 5 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 5 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -49,7 +49,7 @@ DTSTAMP:20260617T190000Z
 DTSTART;TZID=America/Chicago:20260617T190000
 DTEND;TZID=America/Chicago:20260617T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys
-DESCRIPTION:LTTA Tennis match: 5 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 5 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/5/week3.ics
+++ b/teams/wednesday/ics/5/week3.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260610T190000Z
 DTSTART;TZID=America/Chicago:20260610T190000
 DTEND;TZID=America/Chicago:20260610T203000
 SUMMARY:LTTA Tennis: vs Hot Shots (Away)
-DESCRIPTION:LTTA Tennis match: 5 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 5 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/5/week4.ics
+++ b/teams/wednesday/ics/5/week4.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260617T190000Z
 DTSTART;TZID=America/Chicago:20260617T190000
 DTEND;TZID=America/Chicago:20260617T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys (Away)
-DESCRIPTION:LTTA Tennis match: 5 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 5 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/6/team.ics
+++ b/teams/wednesday/ics/6/team.ics
@@ -105,7 +105,7 @@ DTSTAMP:20260715T173000Z
 DTSTART;TZID=America/Chicago:20260715T173000
 DTEND;TZID=America/Chicago:20260715T190000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 6 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 6 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -119,7 +119,7 @@ DTSTAMP:20260722T190000Z
 DTSTART;TZID=America/Chicago:20260722T190000
 DTEND;TZID=America/Chicago:20260722T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys
-DESCRIPTION:LTTA Tennis match: 6 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 6 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/6/week8.ics
+++ b/teams/wednesday/ics/6/week8.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260715T173000Z
 DTSTART;TZID=America/Chicago:20260715T173000
 DTEND;TZID=America/Chicago:20260715T190000
 SUMMARY:LTTA Tennis: vs Hot Shots (Home)
-DESCRIPTION:LTTA Tennis match: 6 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 6 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/6/week9.ics
+++ b/teams/wednesday/ics/6/week9.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260722T190000Z
 DTSTART;TZID=America/Chicago:20260722T190000
 DTEND;TZID=America/Chicago:20260722T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys (Home)
-DESCRIPTION:LTTA Tennis match: 6 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 6 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/7/team.ics
+++ b/teams/wednesday/ics/7/team.ics
@@ -21,7 +21,7 @@ DTSTAMP:20260603T173000Z
 DTSTART;TZID=America/Chicago:20260603T173000
 DTEND;TZID=America/Chicago:20260603T190000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 7 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 7 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M
@@ -35,7 +35,7 @@ DTSTAMP:20260610T190000Z
 DTSTART;TZID=America/Chicago:20260610T190000
 DTEND;TZID=America/Chicago:20260610T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys
-DESCRIPTION:LTTA Tennis match: 7 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 7 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/7/week2.ics
+++ b/teams/wednesday/ics/7/week2.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260603T173000Z
 DTSTART;TZID=America/Chicago:20260603T173000
 DTEND;TZID=America/Chicago:20260603T190000
 SUMMARY:LTTA Tennis: vs Hot Shots (Home)
-DESCRIPTION:LTTA Tennis match: 7 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 7 vs Hot Shots at Green Island Park - Courts 1–5\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/7/week3.ics
+++ b/teams/wednesday/ics/7/week3.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260610T190000Z
 DTSTART;TZID=America/Chicago:20260610T190000
 DTEND;TZID=America/Chicago:20260610T203000
 SUMMARY:LTTA Tennis: vs Rally Monkeys (Away)
-DESCRIPTION:LTTA Tennis match: 7 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 7 vs Rally Monkeys at Green Island Park - Courts 6–9\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/8/team.ics
+++ b/teams/wednesday/ics/8/team.ics
@@ -91,7 +91,7 @@ DTSTAMP:20260708T190000Z
 DTSTART;TZID=America/Chicago:20260708T190000
 DTEND;TZID=America/Chicago:20260708T203000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 8 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 8 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -105,7 +105,7 @@ DTSTAMP:20260715T173000Z
 DTSTART;TZID=America/Chicago:20260715T173000
 DTEND;TZID=America/Chicago:20260715T190000
 SUMMARY:LTTA Tennis: vs Rally Monkeys
-DESCRIPTION:LTTA Tennis match: 8 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 8 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/8/week7.ics
+++ b/teams/wednesday/ics/8/week7.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260708T190000Z
 DTSTART;TZID=America/Chicago:20260708T190000
 DTEND;TZID=America/Chicago:20260708T203000
 SUMMARY:LTTA Tennis: vs Hot Shots (Home)
-DESCRIPTION:LTTA Tennis match: 8 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 8 vs Hot Shots at Green Island Park - Courts 10–13\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/8/week8.ics
+++ b/teams/wednesday/ics/8/week8.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260715T173000Z
 DTSTART;TZID=America/Chicago:20260715T173000
 DTEND;TZID=America/Chicago:20260715T190000
 SUMMARY:LTTA Tennis: vs Rally Monkeys (Home)
-DESCRIPTION:LTTA Tennis match: 8 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 8 vs Rally Monkeys at Green Island Park - Courts 1–5\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 1–5
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/9/team.ics
+++ b/teams/wednesday/ics/9/team.ics
@@ -7,7 +7,7 @@ DTSTAMP:20260527T190000Z
 DTSTART;TZID=America/Chicago:20260527T190000
 DTEND;TZID=America/Chicago:20260527T203000
 SUMMARY:LTTA Tennis: vs Hot Shots
-DESCRIPTION:LTTA Tennis match: 9 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 9 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H
@@ -21,7 +21,7 @@ DTSTAMP:20260603T173000Z
 DTSTART;TZID=America/Chicago:20260603T173000
 DTEND;TZID=America/Chicago:20260603T190000
 SUMMARY:LTTA Tennis: vs Rally Monkeys
-DESCRIPTION:LTTA Tennis match: 9 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 9 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M

--- a/teams/wednesday/ics/9/week1.ics
+++ b/teams/wednesday/ics/9/week1.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260527T190000Z
 DTSTART;TZID=America/Chicago:20260527T190000
 DTEND;TZID=America/Chicago:20260527T203000
 SUMMARY:LTTA Tennis: vs Hot Shots (Away)
-DESCRIPTION:LTTA Tennis match: 9 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Jenna Helminski Juve (3); Mike Leonard (4); John Noble (5)
+DESCRIPTION:LTTA Tennis match: 9 vs Hot Shots at Green Island Park - Courts 6–9\nOpponent Roster: Laura Reutlinger (1); Roxie Anderson (2); Chris Kahlow (3); Taylor Nelson (3); Payton Demeyer (3); Tia Leen (3); Mike Leonard (4); John Noble (5)
 LOCATION:Green Island Park - Courts 6–9
 BEGIN:VALARM
 TRIGGER:-PT11H

--- a/teams/wednesday/ics/9/week2.ics
+++ b/teams/wednesday/ics/9/week2.ics
@@ -25,7 +25,7 @@ DTSTAMP:20260603T173000Z
 DTSTART;TZID=America/Chicago:20260603T173000
 DTEND;TZID=America/Chicago:20260603T190000
 SUMMARY:LTTA Tennis: vs Rally Monkeys (Home)
-DESCRIPTION:LTTA Tennis match: 9 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Andrew Horton (5)
+DESCRIPTION:LTTA Tennis match: 9 vs Rally Monkeys at Green Island Park - Courts 10–13\nOpponent Roster: Brett Meddaugh (1); Meredith Holt (2); Ronghui Chen (3); Kayla Holman/Kelly Gorres (3); Mason Engebretsen (3); Isaiah Dahman (3); Sam Hinton (4); Caleb McClung (5)
 LOCATION:Green Island Park - Courts 10–13
 BEGIN:VALARM
 TRIGGER:-PT9H30M


### PR DESCRIPTION
Swaps Tuesday night Week 5 (June 23rd) and Week 10 (July 28th) match schedules to resolve the Subs team conflict, renames Team 2 to Subs on the homepage index.html, and updates the generator script generate-rr.js to handle this programmatically for the 2026 season.