### PR TITLE
fix(audio-score): CORS, DeepSeek migration, and actionable error messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ QDRANT_URL=""
 QDRANT_API_KEY=""
 
 # Supabase Edge Function configuration (server-side only)
-GEMINI_API_KEY_SCORE_PARSING=""
-# Optional: override the Gemini model used by parse-score (defaults to gemini-2.5-flash-lite)
-GEMINI_MODEL_NAME=""
+DEEPSEEK_API_KEY_SCORE_PARSING=""
+# Optional: override the DeepSeek API endpoint or model used by parse-score
+DEEPSEEK_API_URL=""
+DEEPSEEK_MODEL=""

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@ VITE_SUPABASE_URL=""
 VITE_SUPABASE_ANON_KEY=""
 QDRANT_URL=""
 QDRANT_API_KEY=""
+
+# Supabase Edge Function configuration (server-side only)
+GEMINI_API_KEY_SCORE_PARSING=""
+# Optional: override the Gemini model used by parse-score (defaults to gemini-2.5-flash-lite)
+GEMINI_MODEL_NAME=""

--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,6 @@ QDRANT_API_KEY=""
 # Supabase Edge Function configuration (server-side only)
 DEEPSEEK_API_KEY_SCORE_PARSING=""
 # Optional: override the DeepSeek API endpoint or model used by parse-score
+# (defaults to https://api.deepseek.com and deepseek-v4-flash)
 DEEPSEEK_API_URL=""
 DEEPSEEK_MODEL=""

--- a/src/components/AddScore.jsx
+++ b/src/components/AddScore.jsx
@@ -1161,6 +1161,32 @@ export const AddScore = () => {
         </div>
         <div className="score-section card card--interactive">
           <h2>Match Scores</h2>
+
+          <div className="speech-input-area">
+            <button
+              type="button"
+              className={`microphone-button ${isListening ? 'listening' : ''}`}
+              onClick={isListening ? stopListening : startListening}
+              disabled={aiProcessing}
+              aria-label={isListening ? 'Stop listening' : 'Record score by voice'}
+            >
+              {isListening ? '⏹ Stop Listening' : '🎤 Record Score by Voice'}
+            </button>
+            {isListening && (
+              <div className="transcript-display">Listening... speak now</div>
+            )}
+            {!isListening && transcript && (
+              <div className="transcript-display">Heard: &ldquo;{transcript}&rdquo;</div>
+            )}
+            {aiProcessing && <div className="loading-message">AI is parsing your score...</div>}
+            {aiSuccess && <div className="success-message">{aiSuccess}</div>}
+            {aiError && <div className="error-message">{aiError}</div>}
+            {recognitionError && <div className="error-message">{recognitionError}</div>}
+            {!isSpeechRecognitionSupported && (
+              <div className="error-message">Voice scoring is not supported in this browser. Please type the score manually.</div>
+            )}
+          </div>
+
           {(() => {
             const { homeNames, awayNames } = getPlayerDisplayNames();
             const winner = calculateMatchWinner();

--- a/src/hooks/useVoiceScoreInput.js
+++ b/src/hooks/useVoiceScoreInput.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
-import { supabase } from '../scripts/supabaseClient'; // Assuming supabaseClient.js is in scripts
+import { supabase, supabaseConfig } from '../scripts/supabaseClient';
+import { getActionableErrorMessage } from './voiceErrorUtils';
 
 export const useVoiceScoreInput = (onScoreParsed) => {
   const [isListening, setIsListening] = useState(false);
@@ -11,107 +12,156 @@ export const useVoiceScoreInput = (onScoreParsed) => {
 
   const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
   const recognitionRef = useRef(null);
+  const finalTranscriptRef = useRef('');
+  const interimTranscriptRef = useRef('');
+  const onScoreParsedRef = useRef(onScoreParsed);
+  onScoreParsedRef.current = onScoreParsed;
+
+  useEffect(() => {
+    if (!SpeechRecognition) {
+      setRecognitionError('Speech recognition is not supported in this browser. Please use Chrome, Edge, or Safari, or type the score manually.');
+      return;
+    }
+
+    const recognition = new SpeechRecognition();
+    recognition.continuous = false;
+    recognition.interimResults = true;
+    recognition.lang = 'en-US';
+
+    recognition.onstart = () => {
+      setIsListening(true);
+      setRecognitionError('');
+      setAiSuccess('');
+      setAiError('');
+      setTranscript('');
+      finalTranscriptRef.current = '';
+      interimTranscriptRef.current = '';
+    };
+
+    recognition.onresult = (event) => {
+      let interim = '';
+      let final = '';
+
+      for (let i = event.resultIndex; i < event.results.length; ++i) {
+        const piece = event.results[i][0].transcript;
+        if (event.results[i].isFinal) {
+          final += piece;
+        } else {
+          interim += piece;
+        }
+      }
+
+      finalTranscriptRef.current = final;
+      interimTranscriptRef.current = interim;
+      setTranscript(final || interim);
+    };
+
+    recognition.onerror = (event) => {
+      setRecognitionError(`Speech recognition error: ${event.error}. Please try again or type the score manually.`);
+      setIsListening(false);
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+      const text = (finalTranscriptRef.current || interimTranscriptRef.current).trim();
+      if (text) {
+        parseTranscriptWithAI(text);
+      } else {
+        setRecognitionError('No speech was heard. Please try again or type the score manually.');
+      }
+    };
+
+    recognitionRef.current = recognition;
+
+    return () => {
+      if (recognitionRef.current) {
+        try {
+          recognitionRef.current.stop();
+        } catch {
+          // Already stopped; ignore.
+        }
+      }
+    };
+  }, []); // intentionally empty: recognition instance is created once per mount
 
   const parseTranscriptWithAI = async (text) => {
     setAiProcessing(true);
     setAiError('');
     setAiSuccess('');
-    try {
-      const { data: { session } } = await supabase.auth.getSession();
 
+    let statusCode = null;
+    try {
+      const trimmed = text.trim();
+      if (!trimmed) {
+        throw new Error('No speech was detected. Please try again.');
+      }
+
+      const { data: { session } } = await supabase.auth.getSession();
       if (!session) {
         throw new Error('User not authenticated.');
       }
 
-      const response = await fetch(`${supabase.supabaseUrl}/functions/v1/parse-score`, {
+      const baseUrl = supabaseConfig.url || supabase.supabaseUrl;
+      if (!baseUrl) {
+        throw new Error('Supabase URL is not configured.');
+      }
+
+      const response = await fetch(`${baseUrl}/functions/v1/parse-score`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${session.access_token}`,
         },
-        body: JSON.stringify({ transcript: text }),
+        body: JSON.stringify({ transcript: trimmed }),
       });
 
+      statusCode = response.status;
+
       if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || `AI parsing failed with status: ${response.status}`);
+        let errorMessage = `AI parsing failed with status: ${statusCode}`;
+        try {
+          const errorData = await response.json();
+          errorMessage = errorData.error || errorData.message || errorMessage;
+        } catch {
+          // Response body was not valid JSON; use the status message above.
+        }
+        throw new Error(errorMessage);
       }
 
       const parsedData = await response.json();
-
       setAiSuccess('Transcript parsed successfully by AI!');
-      if (onScoreParsed) {
-        onScoreParsed(parsedData);
+      if (onScoreParsedRef.current) {
+        onScoreParsedRef.current(parsedData);
       }
       return parsedData;
     } catch (err) {
-      setAiError('Error parsing score with AI: ' + err.message);
+      setAiError(getActionableErrorMessage(err, statusCode));
       return null;
     } finally {
       setAiProcessing(false);
     }
   };
 
-  useEffect(() => {
-    if (SpeechRecognition) {
-      recognitionRef.current = new SpeechRecognition();
-      recognitionRef.current.continuous = false;
-      recognitionRef.current.interimResults = true;
-      recognitionRef.current.lang = 'en-US';
-
-      recognitionRef.current.onstart = () => {
-        setIsListening(true);
-        setRecognitionError('');
-        setAiSuccess('');
-        setAiError('');
-        setTranscript('');
-      };
-
-      recognitionRef.current.onresult = (event) => {
-        let interimTranscript = '';
-        let finalTranscript = '';
-
-        for (let i = event.resultIndex; i < event.results.length; ++i) {
-          if (event.results[i].isFinal) {
-            finalTranscript += event.results[i][0].transcript;
-          } else {
-            interimTranscript += event.results[i][0].transcript;
-          }
-        }
-        setTranscript(finalTranscript || interimTranscript);
-      };
-
-      recognitionRef.current.onerror = (event) => {
-        setRecognitionError(`Speech recognition error: ${event.error}`);
-        setIsListening(false);
-      };
-
-      recognitionRef.current.onend = () => {
-        setIsListening(false);
-        if (transcript) {
-          parseTranscriptWithAI(transcript);
-        }
-      };
-    } else {
-      setRecognitionError('Speech Recognition not supported in this browser.');
-    }
-
-    return () => {
-      if (recognitionRef.current) {
-        recognitionRef.current.stop();
-      }
-    };
-  }, [SpeechRecognition, transcript, onScoreParsed]); // Add onScoreParsed to dependencies
-
   const startListening = () => {
     if (recognitionRef.current && !isListening) {
-      recognitionRef.current.start();
+      setRecognitionError('');
+      setAiError('');
+      setAiSuccess('');
+      try {
+        recognitionRef.current.start();
+      } catch (err) {
+        setRecognitionError(`Could not start speech recognition: ${err.message}. Please try again.`);
+      }
     }
   };
 
   const stopListening = () => {
     if (recognitionRef.current && isListening) {
-      recognitionRef.current.stop();
+      try {
+        recognitionRef.current.stop();
+      } catch (err) {
+        // Already stopped; ignore.
+      }
     }
   };
 
@@ -124,6 +174,6 @@ export const useVoiceScoreInput = (onScoreParsed) => {
     aiError,
     startListening,
     stopListening,
-    isSpeechRecognitionSupported: !!SpeechRecognition
+    isSpeechRecognitionSupported: !!SpeechRecognition,
   };
 };

--- a/src/hooks/voiceErrorUtils.js
+++ b/src/hooks/voiceErrorUtils.js
@@ -1,0 +1,31 @@
+export const getActionableErrorMessage = (err, statusCode) => {
+  const raw = err?.message || 'Unknown error';
+
+  // "Load failed" is the generic error Safari/Chrome throws when a fetch is
+  // blocked by CORS, has an invalid URL, or otherwise fails before a response.
+  if (
+    raw === 'Load failed' ||
+    raw.includes('Load failed') ||
+    raw.includes('Failed to fetch') ||
+    raw.includes('NetworkError') ||
+    raw.includes('Network request failed') ||
+    raw.includes('CORS') ||
+    raw.includes('cross-origin')
+  ) {
+    return 'Network error: Could not reach the score parsing service. Please check your internet connection and try again. If the problem persists, the service may be temporarily unavailable.';
+  }
+
+  if (statusCode === 401 || raw.toLowerCase().includes('unauthenticated') || raw.toLowerCase().includes('not authenticated')) {
+    return 'Your session has expired. Please log in again to use voice scoring.';
+  }
+
+  if (statusCode === 500) {
+    return 'Server error: The score parsing service failed. Please try again later.';
+  }
+
+  if (statusCode === 400) {
+    return 'Invalid request: ' + raw;
+  }
+
+  return 'Error parsing score with AI: ' + raw;
+};

--- a/supabase/functions/parse-score/index.ts
+++ b/supabase/functions/parse-score/index.ts
@@ -22,7 +22,7 @@ const jsonResponse = (body: object, status = 200) =>
 const MAX_TRANSCRIPT_LENGTH = 500;
 
 const DEEPSEEK_API_URL = Deno.env.get('DEEPSEEK_API_URL') || 'https://api.deepseek.com';
-const DEEPSEEK_MODEL = Deno.env.get('DEEPSEEK_MODEL') || 'deepseek-chat';
+const DEEPSEEK_MODEL = Deno.env.get('DEEPSEEK_MODEL') || 'deepseek-v4-flash';
 
 serve(async (req) => {
   // Respond to browser preflight requests before the rest of the handler.

--- a/supabase/functions/parse-score/index.ts
+++ b/supabase/functions/parse-score/index.ts
@@ -1,7 +1,6 @@
 import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
-import { GoogleGenerativeAI } from 'https://esm.sh/@google/generative-ai@0.14.0';
 
-console.log('Hello from Functions! (Google SDK Version)');
+console.log('Hello from Functions! (DeepSeek Version)');
 
 // CORS headers must be present on every response so the browser can read it
 // when the frontend calls this function from GitHub Pages / the deployed app.
@@ -21,6 +20,9 @@ const jsonResponse = (body: object, status = 200) =>
   });
 
 const MAX_TRANSCRIPT_LENGTH = 500;
+
+const DEEPSEEK_API_URL = Deno.env.get('DEEPSEEK_API_URL') || 'https://api.deepseek.com';
+const DEEPSEEK_MODEL = Deno.env.get('DEEPSEEK_MODEL') || 'deepseek-chat';
 
 serve(async (req) => {
   // Respond to browser preflight requests before the rest of the handler.
@@ -53,19 +55,13 @@ serve(async (req) => {
     return jsonResponse({ error: `Transcript too long (max ${MAX_TRANSCRIPT_LENGTH} characters)` }, 400);
   }
 
-  const GEMINI_API_KEY = Deno.env.get('GEMINI_API_KEY_SCORE_PARSING');
+  const apiKey = Deno.env.get('DEEPSEEK_API_KEY_SCORE_PARSING');
 
-  if (!GEMINI_API_KEY) {
-    return jsonResponse({ error: 'GEMINI_API_KEY_SCORE_PARSING not set in environment variables' }, 500);
+  if (!apiKey) {
+    return jsonResponse({ error: 'DEEPSEEK_API_KEY_SCORE_PARSING not set in environment variables' }, 500);
   }
 
-  const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
-  // Default to the stable cost-efficient model; allow override via env so it can be
-  // changed without a full code redeploy if Google renames or deprecates a model.
-  const modelName = Deno.env.get('GEMINI_MODEL_NAME') || 'gemini-2.5-flash-lite';
-  const model = genAI.getGenerativeModel({ model: modelName });
-
-  const prompt = `You are a tennis score parsing assistant. Your task is to extract information from a user's spoken transcript of a tennis match score.
+  const systemPrompt = `You are a tennis score parsing assistant. Your task is to extract information from a user's spoken transcript of a tennis match score.
   The output should be a JSON object with the following structure:
   {
     "lineNumber": number, // Optional, defaults to 1 if not specified, but try to infer from "line one", "line two" etc.
@@ -106,15 +102,37 @@ serve(async (req) => {
   - "I lost the first set six two, then won the second six four"
     { "lineNumber": 1, "matchType": "singles", "homeSet1": 2, "awaySet1": 6, "homeSet2": 6, "awaySet2": 4, "homeSet3": null, "awaySet3": null, "notes": "" }
 
-  Always respond with ONLY the JSON object. Do not include any other text or explanation.
-
-  Transcript: "${normalizedTranscript}"
-  `;
+  Always respond with ONLY the JSON object. Do not include any other text or explanation.`;
 
   try {
-    const result = await model.generateContent(prompt);
-    const response = await result.response;
-    const text = response.text();
+    const result = await fetch(`${DEEPSEEK_API_URL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: DEEPSEEK_MODEL,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: `Transcript: "${normalizedTranscript}"` },
+        ],
+        response_format: { type: 'json_object' },
+      }),
+    });
+
+    if (!result.ok) {
+      const errorText = await result.text();
+      console.error('DeepSeek API error:', result.status, errorText);
+      return jsonResponse({ error: 'DeepSeek API request failed', status: result.status, details: errorText }, 500);
+    }
+
+    const data = await result.json();
+    const text = data.choices?.[0]?.message?.content || '';
+
+    if (!text) {
+      return jsonResponse({ error: 'Empty response from DeepSeek API' }, 500);
+    }
 
     // Models sometimes wrap JSON in markdown code fences; strip them before parsing.
     const cleanText = text
@@ -128,13 +146,13 @@ serve(async (req) => {
     try {
       parsedResponse = JSON.parse(cleanText);
     } catch (parseError) {
-      console.error('Error parsing Gemini response as JSON:', parseError);
+      console.error('Error parsing DeepSeek response as JSON:', parseError);
       return jsonResponse({ error: 'Invalid JSON response from AI', rawResponse: text }, 500);
     }
 
     return jsonResponse(parsedResponse, 200);
   } catch (error) {
-    console.error('Error calling Gemini API:', error);
+    console.error('Error calling DeepSeek API:', error);
     return jsonResponse(
       { error: 'Failed to process transcript with AI', details: error?.message || 'Unknown error' },
       500,

--- a/supabase/functions/parse-score/index.ts
+++ b/supabase/functions/parse-score/index.ts
@@ -3,50 +3,67 @@ import { GoogleGenerativeAI } from 'https://esm.sh/@google/generative-ai@0.14.0'
 
 console.log('Hello from Functions! (Google SDK Version)');
 
+// CORS headers must be present on every response so the browser can read it
+// when the frontend calls this function from GitHub Pages / the deployed app.
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const jsonResponse = (body: object, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeaders,
+      'Content-Type': 'application/json',
+    },
+  });
+
+const MAX_TRANSCRIPT_LENGTH = 500;
+
 serve(async (req) => {
-  if (req.method !== 'POST') {
-    return new Response(JSON.stringify({ error: 'Method Not Allowed' }), {
-      headers: { 'Content-Type': 'application/json' },
-      status: 405,
-    });
+  // Respond to browser preflight requests before the rest of the handler.
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders });
   }
 
-  const { transcript } = await req.json();
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method Not Allowed. Use POST.' }, 405);
+  }
+
+  let transcript: unknown;
+  try {
+    const body = await req.json();
+    transcript = body.transcript;
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON in request body' }, 400);
+  }
 
   if (!transcript) {
-    return new Response(JSON.stringify({ error: 'Missing transcript in request body' }), {
-      headers: { 'Content-Type': 'application/json' },
-      status: 400,
-    });
+    return jsonResponse({ error: 'Missing transcript in request body' }, 400);
   }
 
   const normalizedTranscript = typeof transcript === 'string' ? transcript.trim() : '';
   if (!normalizedTranscript) {
-    return new Response(JSON.stringify({ error: 'Transcript must be a non-empty string' }), {
-      headers: { 'Content-Type': 'application/json' },
-      status: 400,
-    });
+    return jsonResponse({ error: 'Transcript must be a non-empty string' }, 400);
   }
 
-  if (normalizedTranscript.length > 500) {
-    return new Response(JSON.stringify({ error: 'Transcript too long (max 500 characters)' }), {
-      headers: { 'Content-Type': 'application/json' },
-      status: 400,
-    });
+  if (normalizedTranscript.length > MAX_TRANSCRIPT_LENGTH) {
+    return jsonResponse({ error: `Transcript too long (max ${MAX_TRANSCRIPT_LENGTH} characters)` }, 400);
   }
 
   const GEMINI_API_KEY = Deno.env.get('GEMINI_API_KEY_SCORE_PARSING');
 
   if (!GEMINI_API_KEY) {
-    return new Response(JSON.stringify({ error: 'GEMINI_API_KEY_SCORE_PARSING not set in environment variables' }), {
-      headers: { 'Content-Type': 'application/json' },
-      status: 500,
-    });
+    return jsonResponse({ error: 'GEMINI_API_KEY_SCORE_PARSING not set in environment variables' }, 500);
   }
 
   const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
-  // Using gemini-2.5-flash-lite for maximum cost efficiency as requested
-  const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash-lite' });
+  // Default to the stable cost-efficient model; allow override via env so it can be
+  // changed without a full code redeploy if Google renames or deprecates a model.
+  const modelName = Deno.env.get('GEMINI_MODEL_NAME') || 'gemini-2.5-flash-lite';
+  const model = genAI.getGenerativeModel({ model: modelName });
 
   const prompt = `You are a tennis score parsing assistant. Your task is to extract information from a user's spoken transcript of a tennis match score.
   The output should be a JSON object with the following structure:
@@ -91,7 +108,7 @@ serve(async (req) => {
 
   Always respond with ONLY the JSON object. Do not include any other text or explanation.
 
-  Transcript: "${transcript}"
+  Transcript: "${normalizedTranscript}"
   `;
 
   try {
@@ -99,27 +116,28 @@ serve(async (req) => {
     const response = await result.response;
     const text = response.text();
 
-    // Attempt to parse the text as JSON
+    // Models sometimes wrap JSON in markdown code fences; strip them before parsing.
+    const cleanText = text
+      .trim()
+      .replace(/^```json\s*/i, '')
+      .replace(/^```/, '')
+      .replace(/```$/, '')
+      .trim();
+
     let parsedResponse;
     try {
-      parsedResponse = JSON.parse(text);
+      parsedResponse = JSON.parse(cleanText);
     } catch (parseError) {
       console.error('Error parsing Gemini response as JSON:', parseError);
-      return new Response(JSON.stringify({ error: 'Invalid JSON response from AI', rawResponse: text }), {
-        headers: { 'Content-Type': 'application/json' },
-        status: 500,
-      });
+      return jsonResponse({ error: 'Invalid JSON response from AI', rawResponse: text }, 500);
     }
 
-    return new Response(JSON.stringify(parsedResponse), {
-      headers: { 'Content-Type': 'application/json' },
-      status: 200,
-    });
+    return jsonResponse(parsedResponse, 200);
   } catch (error) {
     console.error('Error calling Gemini API:', error);
-    return new Response(JSON.stringify({ error: 'Failed to process transcript with AI', details: error.message }), {
-      headers: { 'Content-Type': 'application/json' },
-      status: 500,
-    });
+    return jsonResponse(
+      { error: 'Failed to process transcript with AI', details: error?.message || 'Unknown error' },
+      500,
+    );
   }
 });

--- a/tests/e2e/voice-score-parsing.spec.js
+++ b/tests/e2e/voice-score-parsing.spec.js
@@ -1,0 +1,182 @@
+import { test, expect } from '@playwright/test';
+import { mockSupabaseAuth } from '../utils/auth-mock';
+
+const setupAuthAndData = async (page) => {
+  await mockSupabaseAuth(page, { id: 'fake-user-id', email: 'captain@example.com' });
+
+  // Player profile (AddScore) and role lookup (AuthProvider) both use the same id.
+  await page.route('**/rest/v1/player*', async (route) => {
+    const url = route.request().url();
+    if (url.includes('id=eq.fake-user-id') || url.includes('user_id=eq.fake-user-id')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'fake-user-id',
+          user_id: 'fake-user-id',
+          first_name: 'Captain',
+          last_name: 'Test',
+          is_captain: true,
+          is_admin: true,
+        }),
+      });
+    } else {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+    }
+  });
+
+  await page.route('**/rest/v1/player_to_team*', async (route) => {
+    const url = route.request().url();
+    if (url.includes('player=eq.fake-user-id')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ team: 'fake-team-id' }),
+      });
+    } else {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+    }
+  });
+
+  await page.route('**/rest/v1/team*', async (route) => {
+    const url = route.request().url();
+    if (url.includes('id=eq.fake-team-id')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 'fake-team-id', name: 'My Team', number: 1 }),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 'team-1', number: 1, name: 'Team 1' }),
+      });
+    }
+  });
+
+  await page.route('**/rest/v1/matches*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: 'match-1',
+          home_team_name: 'My Team',
+          home_team_number: 1,
+          home_team_night: 'Monday',
+          away_team_name: 'Opponent Team',
+          away_team_number: 2,
+          away_team_night: 'Monday',
+          date: '2023-10-10',
+          time: '18:00',
+          courts: '1-2',
+        },
+      ]),
+    });
+  });
+
+  await page.route('**/rest/v1/line_results*', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+  });
+};
+
+const injectSpeechRecognitionMock = async (page) => {
+  await page.addInitScript(() => {
+    class MockSpeechRecognition {
+      constructor() {
+        this.continuous = false;
+        this.interimResults = true;
+        this.lang = 'en-US';
+        this.onstart = null;
+        this.onresult = null;
+        this.onerror = null;
+        this.onend = null;
+      }
+      start() {
+        if (this.onstart) this.onstart();
+        setTimeout(() => {
+          if (this.onresult) {
+            this.onresult({
+              resultIndex: 0,
+              results: [[{ transcript: 'Line one doubles, six four, six two', isFinal: true }]],
+            });
+          }
+          if (this.onend) this.onend();
+        }, 50);
+      }
+      stop() {
+        if (this.onend) this.onend();
+      }
+    }
+    window.SpeechRecognition = MockSpeechRecognition;
+    window.webkitSpeechRecognition = MockSpeechRecognition;
+  });
+};
+
+test.describe('Voice score parsing', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupAuthAndData(page);
+    await injectSpeechRecognitionMock(page);
+  });
+
+  test('populates score fields from a successful voice parse', async ({ page }) => {
+    await page.route('**/functions/v1/parse-score', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: { 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify({
+          lineNumber: 1,
+          matchType: 'doubles',
+          homeSet1: 6,
+          awaySet1: 4,
+          homeSet2: 6,
+          awaySet2: 2,
+          homeSet3: null,
+          awaySet3: null,
+          notes: '',
+        }),
+      });
+    });
+
+    await page.goto('/add-score');
+    await expect(page.locator('text=Submit Match Scores')).toBeVisible();
+
+    await page.locator('.microphone-button').click();
+    await expect(page.locator('.success-message')).toContainText('Transcript parsed successfully');
+
+    const scoreSelects = page.locator('.score-inputs select');
+    await expect(scoreSelects.nth(0)).toHaveValue('6'); // homeSet1
+    await expect(scoreSelects.nth(1)).toHaveValue('4'); // awaySet1
+    await expect(scoreSelects.nth(2)).toHaveValue('6'); // homeSet2
+    await expect(scoreSelects.nth(3)).toHaveValue('2'); // awaySet2
+  });
+
+  test('shows an actionable network error when the parsing service cannot be reached', async ({ page }) => {
+    await page.route('**/functions/v1/parse-score', (route) => route.abort());
+
+    await page.goto('/add-score');
+    await expect(page.locator('text=Submit Match Scores')).toBeVisible();
+
+    await page.locator('.microphone-button').click();
+    await expect(page.locator('.error-message')).toContainText('Could not reach the score parsing service');
+  });
+
+  test('shows an actionable server error when the parsing service returns 500', async ({ page }) => {
+    await page.route('**/functions/v1/parse-score', async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        headers: { 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify({ error: 'Failed to process transcript with AI', details: 'model unavailable' }),
+      });
+    });
+
+    await page.goto('/add-score');
+    await expect(page.locator('text=Submit Match Scores')).toBeVisible();
+
+    await page.locator('.microphone-button').click();
+    await expect(page.locator('.error-message')).toContainText('Server error');
+  });
+});

--- a/tests/parse-score-cors.test.js
+++ b/tests/parse-score-cors.test.js
@@ -29,6 +29,6 @@ test('parse-score allows the DeepSeek endpoint/model to be configured via env', 
   assert.ok(content.includes('DEEPSEEK_API_KEY_SCORE_PARSING'), 'should read DEEPSEEK_API_KEY_SCORE_PARSING env var');
   assert.ok(content.includes('DEEPSEEK_API_URL'), 'should read DEEPSEEK_API_URL env var');
   assert.ok(content.includes('DEEPSEEK_MODEL'), 'should read DEEPSEEK_MODEL env var');
-  assert.ok(content.includes('deepseek-chat'), 'should default to deepseek-chat model');
+  assert.ok(content.includes('deepseek-v4-flash'), 'should default to deepseek-v4-flash model');
   assert.ok(content.includes('/chat/completions'), 'should call DeepSeek chat completions endpoint');
 });

--- a/tests/parse-score-cors.test.js
+++ b/tests/parse-score-cors.test.js
@@ -25,7 +25,10 @@ test('parse-score strips markdown code fences from AI responses', () => {
   assert.ok(content.includes('```$'), 'should strip trailing code fences');
 });
 
-test('parse-score allows the model name to be configured via env', () => {
-  assert.ok(content.includes('GEMINI_MODEL_NAME'), 'should read GEMINI_MODEL_NAME env var');
-  assert.ok(content.includes('gemini-2.5-flash-lite'), 'should default to a stable model name');
+test('parse-score allows the DeepSeek endpoint/model to be configured via env', () => {
+  assert.ok(content.includes('DEEPSEEK_API_KEY_SCORE_PARSING'), 'should read DEEPSEEK_API_KEY_SCORE_PARSING env var');
+  assert.ok(content.includes('DEEPSEEK_API_URL'), 'should read DEEPSEEK_API_URL env var');
+  assert.ok(content.includes('DEEPSEEK_MODEL'), 'should read DEEPSEEK_MODEL env var');
+  assert.ok(content.includes('deepseek-chat'), 'should default to deepseek-chat model');
+  assert.ok(content.includes('/chat/completions'), 'should call DeepSeek chat completions endpoint');
 });

--- a/tests/parse-score-cors.test.js
+++ b/tests/parse-score-cors.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const functionPath = path.resolve('supabase/functions/parse-score/index.ts');
+const content = fs.readFileSync(functionPath, 'utf-8');
+
+test('parse-score handles CORS preflight requests', () => {
+  assert.ok(content.includes("req.method === 'OPTIONS'"), 'should handle OPTIONS');
+  assert.ok(content.includes('Access-Control-Allow-Origin'), 'should set Access-Control-Allow-Origin');
+  assert.ok(content.includes('Access-Control-Allow-Headers'), 'should set Access-Control-Allow-Headers');
+  assert.ok(content.includes('Access-Control-Allow-Methods'), 'should set Access-Control-Allow-Methods');
+});
+
+test('parse-score uses the CORS helper for all JSON responses', () => {
+  assert.ok(content.includes('jsonResponse'), 'should define a jsonResponse helper');
+  const occurrences = (content.match(/jsonResponse/g) || []).length;
+  assert.ok(occurrences > 1, 'jsonResponse should be used for multiple responses');
+});
+
+test('parse-score strips markdown code fences from AI responses', () => {
+  assert.ok(content.includes('JSON.parse'), 'should parse JSON');
+  assert.ok(content.includes('```json'), 'should strip json code fences');
+  assert.ok(content.includes('```$'), 'should strip trailing code fences');
+});
+
+test('parse-score allows the model name to be configured via env', () => {
+  assert.ok(content.includes('GEMINI_MODEL_NAME'), 'should read GEMINI_MODEL_NAME env var');
+  assert.ok(content.includes('gemini-2.5-flash-lite'), 'should default to a stable model name');
+});

--- a/tests/voice-error-utils.test.js
+++ b/tests/voice-error-utils.test.js
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { getActionableErrorMessage } from '../src/hooks/voiceErrorUtils.js';
+
+test('classifies Load failed as a network/CORS error', () => {
+  const message = getActionableErrorMessage(new Error('Load failed'), null);
+  assert.ok(message.includes('Network error'));
+  assert.ok(message.includes('score parsing service'));
+});
+
+test('classifies 401 as an authentication error', () => {
+  const message = getActionableErrorMessage(new Error('User not authenticated.'), 401);
+  assert.ok(message.includes('session has expired'));
+});
+
+test('classifies 500 as a server error', () => {
+  const message = getActionableErrorMessage(new Error('AI parsing failed with status: 500'), 500);
+  assert.ok(message.includes('Server error'));
+});
+
+test('classifies 400 as an invalid request error', () => {
+  const message = getActionableErrorMessage(new Error('Transcript too long'), 400);
+  assert.ok(message.includes('Invalid request'));
+});
+
+test('falls back to generic AI parsing error for unknown errors', () => {
+  const message = getActionableErrorMessage(new Error('Something unexpected'), 200);
+  assert.ok(message.startsWith('Error parsing score with AI'));
+});


### PR DESCRIPTION
This MR fixes the audio score-parsing feature reported as failing with "Error parsing score with AI: Load failed".

## Changes
- **Edge Function (`supabase/functions/parse-score/index.ts`)**
  - Replaced Gemini with DeepSeek (`https://api.deepseek.com/chat/completions`).
  - Added CORS handling, including `OPTIONS` preflight and CORS headers on every response.
  - Made DeepSeek URL/model configurable via env vars.
  - Robustly strips markdown code fences before JSON parsing.
- **Frontend Hook (`src/hooks/useVoiceScoreInput.js`)**
  - Fixed stale transcript closure.
  - Classifies network/auth/server errors into actionable messages.
- **AddScore UI (`src/components/AddScore.jsx`)**
  - Wired up the missing microphone button, transcript display, and error/success messages.
- **Tests**
  - Added Node unit tests for error classification and CORS/DeepSeek config.
  - Added Playwright E2E coverage for happy path and failure cases.

## Required secrets
Set these in the Supabase dashboard before deploying:
- `DEEPSEEK_API_KEY_SCORE_PARSING` (required)
- `DEEPSEEK_API_URL` (optional, defaults to `https://api.deepseek.com`)
- `DEEPSEEK_MODEL` (optional, defaults to `deepseek-v4-flash`)

Remove any old `GEMINI_*` secrets if still present.

## Verification
- `node --test tests/voice-error-utils.test.js tests/parse-score-cors.test.js` → 9 passed
- `npm run build` → passes
