### PR TITLE
feat(scores): add Scores tab with Google Sheets CSV data display

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import { MySchedule } from './components/MySchedule';
 import { CourtsLocations } from './components/CourtsLocations';
 import { PlayerResources } from './components/PlayerResources';
 import { SuggestionBox } from './components/SuggestionBox';
+import { Scores } from './components/Scores';
 import { AskTheUmpire } from './components/AskTheUmpire';
 import { AuthProvider } from './context/AuthProvider';
 import './styles/colors.css';
@@ -77,6 +78,7 @@ function App() {
               <Route path="/player-resources" element={<PlayerResources />} />
               <Route path="/feedback" element={<SuggestionBox />} />
               <Route path="/rules" element={<Rules />} />
+              <Route path="/scores" element={<Scores />} />
               <Route path="/standings" element={<Standings />} />
               <Route path="/player-rankings" element={<PlayerRankings />} />
               <Route path="/courts-locations" element={<CourtsLocations />} />

--- a/src/components/AddScore.jsx
+++ b/src/components/AddScore.jsx
@@ -106,20 +106,96 @@ const normalizePlayerSelections = (matchType, players) => {
   return players.map((player) => player ?? '');
 };
 
+const mapHomeAwayToWinnerFirst = (scores) => {
+  const result = {};
+  const setPairs = [
+    [scores.home_set_1, scores.away_set_1],
+    [scores.home_set_2, scores.away_set_2],
+    [scores.home_set_3, scores.away_set_3]
+  ];
+
+  setPairs.forEach(([homeScore, awayScore], index) => {
+    const set = index + 1;
+    const homeScoreNum = homeScore != null ? parseInteger(homeScore) : null;
+    const awayScoreNum = awayScore != null ? parseInteger(awayScore) : null;
+
+    if (homeScoreNum != null && awayScoreNum != null) {
+      const homeWon = homeScoreNum > awayScoreNum;
+      result[`set${set}Winner`] = homeWon ? 'home' : 'away';
+      result[`winnerSet${set}`] = homeWon ? homeScoreNum : awayScoreNum;
+      result[`loserSet${set}`] = homeWon ? awayScoreNum : homeScoreNum;
+    } else {
+      result[`set${set}Winner`] = 'home';
+      result[`winnerSet${set}`] = homeScoreNum?.toString() || '';
+      result[`loserSet${set}`] = awayScoreNum?.toString() || '';
+    }
+  });
+
+  return result;
+};
+
+const mapWinnerFirstToHomeAway = (formData) => {
+  const result = {};
+  for (const set of [1, 2, 3]) {
+    const winner = formData[`set${set}Winner`];
+    const winnerScore = parseInteger(formData[`winnerSet${set}`]);
+    const loserScore = parseInteger(formData[`loserSet${set}`]);
+
+    if (winner === 'home') {
+      result[`homeSet${set}`] = winnerScore;
+      result[`awaySet${set}`] = loserScore;
+    } else {
+      result[`homeSet${set}`] = loserScore;
+      result[`awaySet${set}`] = winnerScore;
+    }
+  }
+  return result;
+};
+
+const convertParsedHomeAwayToWinnerFirst = (parsedData) => {
+  const result = {};
+  for (const set of [1, 2, 3]) {
+    const home = parseInteger(parsedData?.[`homeSet${set}`]);
+    const away = parseInteger(parsedData?.[`awaySet${set}`]);
+
+    if (home != null || away != null) {
+      const homeWon = (home ?? 0) > (away ?? 0);
+      result[`set${set}Winner`] = homeWon ? 'home' : 'away';
+      result[`winnerSet${set}`] = homeWon ? (home ?? '').toString() : (away ?? '').toString();
+      result[`loserSet${set}`] = homeWon ? (away ?? '').toString() : (home ?? '').toString();
+    } else {
+      result[`set${set}Winner`] = 'home';
+      result[`winnerSet${set}`] = '';
+      result[`loserSet${set}`] = '';
+    }
+  }
+  return result;
+};
+
 const buildScorePayload = ({
   matchId,
   lineNumber,
   matchType,
-  homeSet1,
-  homeSet2,
-  homeSet3,
-  awaySet1,
-  awaySet2,
-  awaySet3,
+  winnerSet1,
+  winnerSet2,
+  winnerSet3,
+  loserSet1,
+  loserSet2,
+  loserSet3,
+  set1Winner,
+  set2Winner,
+  set3Winner,
   homePlayers,
   awayPlayers,
   notes
 }, playerIdMap, userId, winner) => {
+  const homeSet1 = set1Winner === 'home' ? winnerSet1 : loserSet1;
+  const awaySet1 = set1Winner === 'home' ? loserSet1 : winnerSet1;
+  const homeSet2 = set2Winner === 'home' ? winnerSet2 : loserSet2;
+  const awaySet2 = set2Winner === 'home' ? loserSet2 : winnerSet2;
+  const homeSet3 = set3Winner === 'home' ? winnerSet3 : loserSet3;
+  const awaySet3 = set3Winner === 'home' ? loserSet3 : winnerSet3;
+
   const home_player_1_id = playerIdMap[homePlayers[0]] || null;
   const home_player_2_id = matchType === 'doubles' ? playerIdMap[homePlayers[1]] || null : null;
   const away_player_1_id = playerIdMap[awayPlayers[0]] || null;
@@ -185,12 +261,15 @@ export const AddScore = () => {
     matchType: 'doubles',
     homePlayers: ['', ''],
     awayPlayers: ['', ''],
-    homeSet1: '',
-    awaySet1: '',
-    homeSet2: '',
-    awaySet2: '',
-    homeSet3: '',
-    awaySet3: '',
+    set1Winner: 'home',
+    set2Winner: 'home',
+    set3Winner: 'home',
+    winnerSet1: '',
+    loserSet1: '',
+    winnerSet2: '',
+    loserSet2: '',
+    winnerSet3: '',
+    loserSet3: '',
     notes: ''
   });
   const {
@@ -209,31 +288,28 @@ export const AddScore = () => {
       ? parsedData.matchType
       : formData.matchType;
 
+    const winnerFirstScores = convertParsedHomeAwayToWinnerFirst(parsedData);
+
     const nextForm = {
       ...formData,
       lineNumber: sanitizedLineNumber,
       matchType: sanitizedMatchType,
-      homeSet1: parsedData?.homeSet1 != null ? parseInteger(parsedData.homeSet1) : null,
-      awaySet1: parsedData?.awaySet1 != null ? parseInteger(parsedData.awaySet1) : null,
-      homeSet2: parsedData?.homeSet2 != null ? parseInteger(parsedData.homeSet2) : null,
-      awaySet2: parsedData?.awaySet2 != null ? parseInteger(parsedData.awaySet2) : null,
-      homeSet3: parsedData?.homeSet3 != null ? parseInteger(parsedData.homeSet3) : null,
-      awaySet3: parsedData?.awaySet3 != null ? parseInteger(parsedData.awaySet3) : null,
+      ...winnerFirstScores,
       notes: parsedData?.notes?.trim?.() || formData.notes
     };
 
-    const set1Home = parseInteger(nextForm.homeSet1);
-    const set1Away = parseInteger(nextForm.awaySet1);
-    const set2Home = parseInteger(nextForm.homeSet2);
-    const set2Away = parseInteger(nextForm.awaySet2);
-    const set3Home = parseInteger(nextForm.homeSet3);
-    const set3Away = parseInteger(nextForm.awaySet3);
+    const set1WinnerScore = parseInteger(nextForm.winnerSet1);
+    const set1LoserScore = parseInteger(nextForm.loserSet1);
+    const set2WinnerScore = parseInteger(nextForm.winnerSet2);
+    const set2LoserScore = parseInteger(nextForm.loserSet2);
+    const set3WinnerScore = parseInteger(nextForm.winnerSet3);
+    const set3LoserScore = parseInteger(nextForm.loserSet3);
 
-    const hasThirdSet = !isEmptyValue(nextForm.homeSet3) || !isEmptyValue(nextForm.awaySet3);
+    const hasThirdSet = !isEmptyValue(nextForm.winnerSet3) || !isEmptyValue(nextForm.loserSet3);
     const invalid =
-      !isStandardSetValid(set1Home, set1Away) ||
-      !isStandardSetValid(set2Home, set2Away) ||
-      (hasThirdSet && !isMatchTiebreakValid(set3Home, set3Away));
+      !isStandardSetValid(set1WinnerScore, set1LoserScore) ||
+      !isStandardSetValid(set2WinnerScore, set2LoserScore) ||
+      (hasThirdSet && !isMatchTiebreakValid(set3WinnerScore, set3LoserScore));
 
     if (invalid) {
       setError('AI parsed an invalid score. Please correct the values and try again.');
@@ -247,12 +323,7 @@ export const AddScore = () => {
       matchType: sanitizedMatchType,
       homePlayers: matchOrLineChanged ? ['', ''] : prev.homePlayers,
       awayPlayers: matchOrLineChanged ? ['', ''] : prev.awayPlayers,
-      homeSet1: nextForm.homeSet1?.toString() || '',
-      awaySet1: nextForm.awaySet1?.toString() || '',
-      homeSet2: nextForm.homeSet2?.toString() || '',
-      awaySet2: nextForm.awaySet2?.toString() || '',
-      homeSet3: nextForm.homeSet3?.toString() || '',
-      awaySet3: nextForm.awaySet3?.toString() || '',
+      ...winnerFirstScores,
       notes: nextForm.notes
     }));
     setError('');
@@ -345,7 +416,7 @@ export const AddScore = () => {
     return roster; // Default to all if line not specified
   };
 
-  const loadExistingScores = async (matchId) => {
+  const loadExistingScores = async (matchId, { skipPopulate = false } = {}) => {
     try {
       const { data: scores, error } = await supabase
         .from('line_results')
@@ -364,12 +435,17 @@ export const AddScore = () => {
       setExistingScores(scores || []);
 
       // If there's a score for the current line, populate the form
-      const currentLineScore = scores?.find(s => s.line_number === formData.lineNumber);
-      if (currentLineScore) {
-        populateFormWithExistingScore(currentLineScore);
+      if (!skipPopulate) {
+        const currentLineScore = scores?.find(s => s.line_number === formData.lineNumber);
+        if (currentLineScore) {
+          populateFormWithExistingScore(currentLineScore);
+        }
       }
+
+      return scores || [];
     } catch (err) {
       console.error('Error loading existing scores:', err);
+      return [];
     }
   };
 
@@ -384,17 +460,21 @@ export const AddScore = () => {
       score.away_player_2 ? `${score.away_player_2.first_name} ${score.away_player_2.last_name}` : ''
     ];
 
+    const winnerFirstScores = mapHomeAwayToWinnerFirst({
+      home_set_1: score.home_set_1,
+      away_set_1: score.away_set_1,
+      home_set_2: score.home_set_2,
+      away_set_2: score.away_set_2,
+      home_set_3: score.home_set_3,
+      away_set_3: score.away_set_3
+    });
+
     setFormData(prev => ({
       ...prev,
       matchType: score.match_type,
       homePlayers,
       awayPlayers,
-      homeSet1: score.home_set_1?.toString() || '',
-      awaySet1: score.away_set_1?.toString() || '',
-      homeSet2: score.home_set_2?.toString() || '',
-      awaySet2: score.away_set_2?.toString() || '',
-      homeSet3: score.home_set_3?.toString() || '',
-      awaySet3: score.away_set_3?.toString() || '',
+      ...winnerFirstScores,
       notes: score.notes || ''
     }));
   };
@@ -524,12 +604,15 @@ export const AddScore = () => {
         ...prev,
         homePlayers: ['', ''],
         awayPlayers: ['', ''],
-        homeSet1: '',
-        awaySet1: '',
-        homeSet2: '',
-        awaySet2: '',
-        homeSet3: '',
-        awaySet3: '',
+        set1Winner: 'home',
+        set2Winner: 'home',
+        set3Winner: 'home',
+        winnerSet1: '',
+        loserSet1: '',
+        winnerSet2: '',
+        loserSet2: '',
+        winnerSet3: '',
+        loserSet3: '',
         notes: ''
       }));
       autoSelectPlayers(homeTeamRoster, awayTeamRoster, numericLine, effectiveMatchType);
@@ -573,11 +656,18 @@ export const AddScore = () => {
     }));
   };
 
-  const handleScoreChange = (team, set, value) => {
+  const handleScoreChange = (type, set, value) => {
     const scoreValue = value === '' ? '' : value.replace(/[^0-9]/g, '');
     setFormData(prev => ({
       ...prev,
-      [`${team}Set${set}`]: scoreValue
+      [`${type}Set${set}`]: scoreValue
+    }));
+  };
+
+  const handleSetWinnerChange = (set, value) => {
+    setFormData(prev => ({
+      ...prev,
+      [`set${set}Winner`]: value
     }));
   };
 
@@ -599,12 +689,13 @@ export const AddScore = () => {
 
   // Calculate match winner based on current scores
   const calculateMatchWinner = () => {
-    const homeSet1 = parseInt(formData.homeSet1) || 0;
-    const awaySet1 = parseInt(formData.awaySet1) || 0;
-    const homeSet2 = parseInt(formData.homeSet2) || 0;
-    const awaySet2 = parseInt(formData.awaySet2) || 0;
-    const homeSet3 = parseInt(formData.homeSet3) || 0;
-    const awaySet3 = parseInt(formData.awaySet3) || 0;
+    const homeAwayScores = mapWinnerFirstToHomeAway(formData);
+    const homeSet1 = parseInt(homeAwayScores.homeSet1) || 0;
+    const awaySet1 = parseInt(homeAwayScores.awaySet1) || 0;
+    const homeSet2 = parseInt(homeAwayScores.homeSet2) || 0;
+    const awaySet2 = parseInt(homeAwayScores.awaySet2) || 0;
+    const homeSet3 = parseInt(homeAwayScores.homeSet3) || 0;
+    const awaySet3 = parseInt(homeAwayScores.awaySet3) || 0;
 
     let homeSetsWon = 0;
     let awaySetsWon = 0;
@@ -693,31 +784,69 @@ export const AddScore = () => {
     }
   };
 
+  const unsavedScoresByMatchRef = useRef({});
+
   const handleMatchSelect = async (matchId) => {
     const match = availableMatches.find(m => m.id === matchId);
-    if (match) {
-      setSelectedMatch(match);
-      setFormData(prev => ({
-        ...prev,
-        matchId: matchId,
-        homePlayers: ['', ''],
-        awayPlayers: ['', '']
-      }));
+    if (!match) return;
 
-      // Load rosters for both teams
-      const [homeRoster, awayRoster] = await Promise.all([
-        loadTeamRoster(match.home_team_number, match.home_team_night),
-        loadTeamRoster(match.away_team_number, match.away_team_night)
-      ]);
+    // If already on this match, nothing to do
+    if (formData.matchId === matchId) return;
 
-      setHomeTeamRoster(homeRoster);
-      setAwayTeamRoster(awayRoster);
+    // Save current form data for the previously selected match (if any)
+    if (formData.matchId) {
+      unsavedScoresByMatchRef.current[formData.matchId] = { ...formData };
+    }
 
-      // Load existing scores for this match
-      await loadExistingScores(matchId);
+    setSelectedMatch(match);
 
-      // Auto-select players if there are few options
-      autoSelectPlayers(homeRoster, awayRoster, formData.lineNumber, formData.matchType);
+    // Load rosters for both teams
+    const [homeRoster, awayRoster] = await Promise.all([
+      loadTeamRoster(match.home_team_number, match.home_team_night),
+      loadTeamRoster(match.away_team_number, match.away_team_night)
+    ]);
+
+    setHomeTeamRoster(homeRoster);
+    setAwayTeamRoster(awayRoster);
+
+    // Load existing DB scores without overwriting the form yet
+    const scores = await loadExistingScores(matchId, { skipPopulate: true });
+
+    // Restore unsaved scores for this match if available
+    const unsaved = unsavedScoresByMatchRef.current[matchId];
+    if (unsaved) {
+      setFormData({
+        ...unsaved,
+        matchId: matchId
+      });
+      return;
+    }
+
+    // No unsaved data: reset form for this match and populate from DB if available
+    const currentLine = formData.lineNumber;
+    setFormData(prev => ({
+      ...prev,
+      matchId: matchId,
+      lineNumber: currentLine,
+      homePlayers: ['', ''],
+      awayPlayers: ['', ''],
+      set1Winner: 'home',
+      set2Winner: 'home',
+      set3Winner: 'home',
+      winnerSet1: '',
+      loserSet1: '',
+      winnerSet2: '',
+      loserSet2: '',
+      winnerSet3: '',
+      loserSet3: '',
+      notes: ''
+    }));
+
+    const existingScore = scores.find(s => s.line_number === currentLine);
+    if (existingScore) {
+      populateFormWithExistingScore(existingScore);
+    } else {
+      autoSelectPlayers(homeRoster, awayRoster, currentLine, formData.matchType);
     }
   };
 
@@ -740,20 +869,20 @@ export const AddScore = () => {
       return false;
     }
 
-    const set1Home = parseInteger(formData.homeSet1);
-    const set1Away = parseInteger(formData.awaySet1);
-    const set2Home = parseInteger(formData.homeSet2);
-    const set2Away = parseInteger(formData.awaySet2);
-    const set3Home = parseInteger(formData.homeSet3);
-    const set3Away = parseInteger(formData.awaySet3);
+    const set1Winner = parseInteger(formData.winnerSet1);
+    const set1Loser = parseInteger(formData.loserSet1);
+    const set2Winner = parseInteger(formData.winnerSet2);
+    const set2Loser = parseInteger(formData.loserSet2);
+    const set3Winner = parseInteger(formData.winnerSet3);
+    const set3Loser = parseInteger(formData.loserSet3);
 
-    if (!isStandardSetValid(set1Home, set1Away) || !isStandardSetValid(set2Home, set2Away)) {
+    if (!isStandardSetValid(set1Winner, set1Loser) || !isStandardSetValid(set2Winner, set2Loser)) {
       setError('Sets 1 and 2 must be valid tennis scores (win by 2, 6-4/7-5/7-6 etc.)');
       return false;
     }
 
-    if (!isEmptyValue(formData.homeSet3) || !isEmptyValue(formData.awaySet3)) {
-      if (!isMatchTiebreakValid(set3Home, set3Away)) {
+    if (!isEmptyValue(formData.winnerSet3) || !isEmptyValue(formData.loserSet3)) {
+      if (!isMatchTiebreakValid(set3Winner, set3Loser)) {
         setError('Third set must be a valid tiebreak (first to 7, win by 2) or blank');
         return false;
       }
@@ -793,12 +922,15 @@ export const AddScore = () => {
         matchId: selectedMatch.id,
         lineNumber: formData.lineNumber,
         matchType: formData.matchType,
-        homeSet1: formData.homeSet1,
-        homeSet2: formData.homeSet2,
-        homeSet3: formData.homeSet3,
-        awaySet1: formData.awaySet1,
-        awaySet2: formData.awaySet2,
-        awaySet3: formData.awaySet3,
+        winnerSet1: formData.winnerSet1,
+        winnerSet2: formData.winnerSet2,
+        winnerSet3: formData.winnerSet3,
+        loserSet1: formData.loserSet1,
+        loserSet2: formData.loserSet2,
+        loserSet3: formData.loserSet3,
+        set1Winner: formData.set1Winner,
+        set2Winner: formData.set2Winner,
+        set3Winner: formData.set3Winner,
         homePlayers: normalizedHomePlayers,
         awayPlayers: normalizedAwayPlayers,
         notes: formData.notes
@@ -847,18 +979,23 @@ export const AddScore = () => {
 
       // Reload existing scores to reflect changes
       await loadExistingScores(selectedMatch.id);
+      // Clear unsaved cache for this match since it is now saved
+      delete unsavedScoresByMatchRef.current[selectedMatch.id];
       // Reset form
       setFormData(prev => ({
         ...prev,
         matchId: '',
         homePlayers: ['', ''],
         awayPlayers: ['', ''],
-        homeSet1: '',
-        awaySet1: '',
-        homeSet2: '',
-        awaySet2: '',
-        homeSet3: '',
-        awaySet3: '',
+        set1Winner: 'home',
+        set2Winner: 'home',
+        set3Winner: 'home',
+        winnerSet1: '',
+        loserSet1: '',
+        winnerSet2: '',
+        loserSet2: '',
+        winnerSet3: '',
+        loserSet3: '',
         notes: ''
       }));
       setSelectedMatch(null);
@@ -1019,14 +1156,30 @@ export const AddScore = () => {
             <div className="existing-scores-summary card card--interactive card--overlay">
               <h4>Existing Scores for this Match:</h4>
               <div className="scores-grid">
-                {existingScores.map(score => (
-                  <div key={score.id} className="score-summary card card--interactive card--overlay">
-                    <strong>Line {score.line_number}</strong> ({score.match_type}):
-                    {score.home_set_1}-{score.away_set_1}, {score.home_set_2}-{score.away_set_2}
-                    {score.home_set_3 && `, ${score.home_set_3}-${score.away_set_3}`}
-                    {score.home_won ? ' (Home Won)' : ' (Away Won)'}
-                  </div>
-                ))}
+                {existingScores.map(score => {
+                  const formatted = mapHomeAwayToWinnerFirst({
+                    home_set_1: score.home_set_1,
+                    away_set_1: score.away_set_1,
+                    home_set_2: score.home_set_2,
+                    away_set_2: score.away_set_2,
+                    home_set_3: score.home_set_3,
+                    away_set_3: score.away_set_3
+                  });
+                  const set3Display = formatted.winnerSet3 || formatted.loserSet3
+                    ? `, ${formatted.winnerSet3}-${formatted.loserSet3}`
+                    : '';
+                  const set1Team = formatted.set1Winner === 'home' ? selectedMatch?.home_team_name : selectedMatch?.away_team_name;
+                  const set2Team = formatted.set2Winner === 'home' ? selectedMatch?.home_team_name : selectedMatch?.away_team_name;
+                  return (
+                    <div key={score.id} className="score-summary card card--interactive card--overlay">
+                      <strong>Line {score.line_number}</strong> ({score.match_type}):
+                      <div>{formatted.winnerSet1}-{formatted.loserSet1} ({set1Team})</div>
+                      <div>{formatted.winnerSet2}-{formatted.loserSet2} ({set2Team})</div>
+                      {set3Display && <div>{set3Display} (tiebreak)</div>}
+                      {score.home_won ? ' (Home Won)' : ' (Away Won)'}
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}
@@ -1189,64 +1342,90 @@ export const AddScore = () => {
           <div className="score-row">
             <div className="score-group">
               <label>Set 1</label>
+              <select
+                className="set-winner-select"
+                value={formData.set1Winner}
+                onChange={(e) => handleSetWinnerChange(1, e.target.value)}
+                required
+              >
+                <option value="home">{selectedMatch?.home_team_name || 'Home'} won</option>
+                <option value="away">{selectedMatch?.away_team_name || 'Away'} won</option>
+              </select>
               <div className="score-inputs">
                 <select
-                  value={formData.homeSet1}
-                  onChange={(e) => handleScoreChange('home', 1, e.target.value)}
+                  value={formData.winnerSet1}
+                  onChange={(e) => handleScoreChange('winner', 1, e.target.value)}
                   required
                 >
-                  <option value="">{getPlayerDisplayNames().homeNames || 'Home'}</option>
+                  <option value="">Winner</option>
                   {generateScoreOptions()}
                 </select>
                 <span>-</span>
                 <select
-                  value={formData.awaySet1}
-                  onChange={(e) => handleScoreChange('away', 1, e.target.value)}
+                  value={formData.loserSet1}
+                  onChange={(e) => handleScoreChange('loser', 1, e.target.value)}
                   required
                 >
-                  <option value="">{getPlayerDisplayNames().awayNames || 'Away'}</option>
+                  <option value="">Loser</option>
                   {generateScoreOptions()}
                 </select>
               </div>
             </div>
             <div className="score-group">
               <label>Set 2</label>
+              <select
+                className="set-winner-select"
+                value={formData.set2Winner}
+                onChange={(e) => handleSetWinnerChange(2, e.target.value)}
+                required
+              >
+                <option value="home">{selectedMatch?.home_team_name || 'Home'} won</option>
+                <option value="away">{selectedMatch?.away_team_name || 'Away'} won</option>
+              </select>
               <div className="score-inputs">
                 <select
-                  value={formData.homeSet2}
-                  onChange={(e) => handleScoreChange('home', 2, e.target.value)}
+                  value={formData.winnerSet2}
+                  onChange={(e) => handleScoreChange('winner', 2, e.target.value)}
                   required
                 >
-                  <option value="">{getPlayerDisplayNames().homeNames || 'Home'}</option>
+                  <option value="">Winner</option>
                   {generateScoreOptions()}
                 </select>
                 <span>-</span>
                 <select
-                  value={formData.awaySet2}
-                  onChange={(e) => handleScoreChange('away', 2, e.target.value)}
+                  value={formData.loserSet2}
+                  onChange={(e) => handleScoreChange('loser', 2, e.target.value)}
                   required
                 >
-                  <option value="">{getPlayerDisplayNames().awayNames || 'Away'}</option>
+                  <option value="">Loser</option>
                   {generateScoreOptions()}
                 </select>
               </div>
             </div>
             <div className="score-group">
               <label>Set 3 (Tiebreak)</label>
+              <select
+                className="set-winner-select"
+                value={formData.set3Winner}
+                onChange={(e) => handleSetWinnerChange(3, e.target.value)}
+              >
+                <option value="home">{selectedMatch?.home_team_name || 'Home'} won</option>
+                <option value="away">{selectedMatch?.away_team_name || 'Away'} won</option>
+              </select>
               <div className="score-inputs">
                 <select
-                  value={formData.homeSet3}
-                  onChange={(e) => handleScoreChange('home', 3, e.target.value)}
+                  value={formData.winnerSet3}
+                  onChange={(e) => handleScoreChange('winner', 3, e.target.value)}
                 >
-                  <option value="">{getPlayerDisplayNames().homeNames || 'Home'}</option>
+                  <option value="">Winner</option>
                   {generateTiebreakOptions()}
                 </select>
                 <span>-</span>
                 <select
-                  value={formData.awaySet3}
-                  onChange={(e) => handleScoreChange('away', 3, e.target.value)}
+                  value={formData.loserSet3}
+                  onChange={(e) => handleScoreChange('loser', 3, e.target.value)}
                 >
-                  <option value="">{getPlayerDisplayNames().awayNames || 'Away'}</option>
+                  <option value="">Loser</option>
                   {generateTiebreakOptions()}
                 </select>
               </div>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -90,7 +90,6 @@ export const Navigation = ({ theme = 'light', onToggleTheme = () => { } }) => {
                 </button>
                 <ul className={`dropdown-menu ${openDropdown === 'league' ? 'show' : ''}`} role="menu">
                   <li><Link to="/standings" onClick={closeMenu}>Standings</Link></li>
-                  <li><Link to="/scores" onClick={closeMenu}>Scores</Link></li>
                   <li><Link to="/player-rankings" onClick={closeMenu}>Player Rankings</Link></li>
                   <li>
                     <a

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -90,6 +90,7 @@ export const Navigation = ({ theme = 'light', onToggleTheme = () => { } }) => {
                 </button>
                 <ul className={`dropdown-menu ${openDropdown === 'league' ? 'show' : ''}`} role="menu">
                   <li><Link to="/standings" onClick={closeMenu}>Standings</Link></li>
+                  <li><Link to="/scores" onClick={closeMenu}>Scores</Link></li>
                   <li><Link to="/player-rankings" onClick={closeMenu}>Player Rankings</Link></li>
                   <li>
                     <a

--- a/src/components/Scores.jsx
+++ b/src/components/Scores.jsx
@@ -1,0 +1,308 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import '../styles/Style.css';
+import '../styles/Scores.css';
+
+const CSV_URL =
+  'https://docs.google.com/spreadsheets/d/e/2PACX-1vTRXXJgqymosDbuyhAHCpHHUqQsNxRk0B-3kBGWr7CuPymhKUpT83JKyN7DxkCiaPdKsZEeBaA3GDjH/pub?gid=1910758219&single=true&output=csv';
+
+// Simple CSV parser for this specific format (no quoted fields, no embedded commas)
+const parseCSV = (text) => {
+  const lines = text.trim().split('\n');
+  if (lines.length < 2) return { headers: [], rows: [] };
+
+  const headers = lines[0].split(',').map((h) => h.trim());
+  const rows = lines.slice(1).map((line) => {
+    const values = line.split(',');
+    return headers.reduce((obj, header, i) => {
+      obj[header] = (values[i] || '').trim();
+      return obj;
+    }, {});
+  });
+
+  return { headers, rows };
+};
+
+// Extract week column numbers from headers
+const getWeekColumns = (headers) => {
+  return headers.filter((h) => /^Week\s+\d+$/i.test(h));
+};
+
+// Format a cell value for display
+const formatCellValue = (value) => {
+  if (value === '' || value === undefined || value === null)
+    return { text: '\u2014', className: 'cell-empty' };
+  if (value.toUpperCase() === 'WEATHER')
+    return { text: 'WEATHER', className: 'cell-weather', title: 'Match postponed due to weather' };
+  if (value === '?')
+    return { text: '?', className: 'cell-unknown', title: 'Score not yet reported' };
+  const num = Number(value);
+  if (!isNaN(num)) return { text: value, className: 'cell-score' };
+  return { text: value, className: 'cell-text' };
+};
+
+const Scores = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [allRows, setAllRows] = useState([]);
+  const [weekColumns, setWeekColumns] = useState([]);
+  const [activeNight, setActiveNight] = useState('All');
+  const [lastUpdated, setLastUpdated] = useState('');
+
+  const fetchScores = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError('');
+
+      const response = await fetch(CSV_URL);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch scores (HTTP ${response.status})`);
+      }
+
+      const text = await response.text();
+      if (!text || text.trim().length === 0) {
+        throw new Error('Received empty response from scores data source.');
+      }
+
+      // Basic validation - check it looks like CSV
+      const firstLine = text.trim().split('\n')[0];
+      if (firstLine.startsWith('<') || firstLine.toLowerCase().startsWith('<!doctype')) {
+        throw new Error('Received HTML instead of CSV. The data source may be unavailable.');
+      }
+
+      const { headers, rows } = parseCSV(text);
+
+      if (rows.length === 0) {
+        setAllRows([]);
+        setWeekColumns([]);
+        setLastUpdated(new Date().toISOString());
+        setLoading(false);
+        return;
+      }
+
+      const weeks = getWeekColumns(headers);
+      setWeekColumns(weeks);
+      setAllRows(rows);
+      setLastUpdated(new Date().toISOString());
+    } catch (err) {
+      console.error('Error fetching scores:', err);
+      setError(err.message || 'Unable to load scores at this time.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchScores();
+  }, [fetchScores]);
+
+  // Group rows by night
+  const nightGroups = useMemo(() => {
+    const grouped = {};
+    allRows.forEach((row) => {
+      const night = (row.Night || '').trim();
+      if (!night) return;
+      const key = night.toLowerCase();
+      if (!grouped[key]) {
+        grouped[key] = { night, teams: [] };
+      }
+      grouped[key].teams.push(row);
+    });
+
+    // Sort teams within each night by total points (descending)
+    Object.values(grouped).forEach((group) => {
+      group.teams.sort((a, b) => {
+        const aPts = parseInt(a['Total Points'], 10) || 0;
+        const bPts = parseInt(b['Total Points'], 10) || 0;
+        if (bPts !== aPts) return bPts - aPts;
+        return (a['Team Name'] || '').localeCompare(b['Team Name'] || '');
+      });
+    });
+
+    return grouped;
+  }, [allRows]);
+
+  const nightKeys = useMemo(() => {
+    const order = ['tuesday', 'wednesday'];
+    return order.filter((key) => nightGroups[key]);
+  }, [nightGroups]);
+
+  const filteredNightKeys = useMemo(() => {
+    if (activeNight === 'All') return nightKeys;
+    return nightKeys.filter((key) => key === activeNight.toLowerCase());
+  }, [nightKeys, activeNight]);
+
+  const formattedUpdatedAt = lastUpdated
+    ? new Date(lastUpdated).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    : '';
+
+  return (
+    <main className="scores-page">
+      <div className="scores-header">
+        <h1>Team Scores</h1>
+        <p>Weekly points earned by each team, sourced from the league spreadsheet.</p>
+      </div>
+
+      {loading ? (
+        <div className="loading-state card card--interactive">
+          <p>Loading scores...</p>
+        </div>
+      ) : error ? (
+        <div className="error-state card card--interactive">
+          <p>{error}</p>
+          <button type="button" className="refresh-btn" onClick={fetchScores}>
+            Try Again
+          </button>
+        </div>
+      ) : allRows.length === 0 ? (
+        <div className="empty-state card card--interactive">
+          <p>No score data available yet.</p>
+          <button type="button" className="refresh-btn" onClick={fetchScores}>
+            Refresh
+          </button>
+        </div>
+      ) : (
+        <>
+          {/* Night filter controls */}
+          <div className="scores-controls card card--interactive">
+            <div className="scores-controls-header">
+              <div className="controls-copy">
+                <span className="controls-title">Filter by league night</span>
+                <span className="controls-subtitle">
+                  {activeNight === 'All'
+                    ? 'Showing all leagues'
+                    : `Showing ${activeNight} league`}
+                </span>
+              </div>
+              <button
+                type="button"
+                className="refresh-btn"
+                onClick={fetchScores}
+                aria-label="Refresh scores"
+              >
+                Refresh Scores
+              </button>
+            </div>
+            <div className="night-filter-group">
+              <button
+                type="button"
+                className={`night-filter ${activeNight === 'All' ? 'active' : ''}`}
+                onClick={() => setActiveNight('All')}
+              >
+                All
+              </button>
+              {nightKeys.map((key) => (
+                <button
+                  key={key}
+                  type="button"
+                  className={`night-filter ${activeNight === nightGroups[key].night ? 'active' : ''}`}
+                  onClick={() => setActiveNight(nightGroups[key].night)}
+                >
+                  {nightGroups[key].night}
+                </button>
+              ))}
+            </div>
+            {formattedUpdatedAt && (
+              <div className="updated-at">Last updated {formattedUpdatedAt}</div>
+            )}
+          </div>
+
+          {/* Legend */}
+          <div className="scores-legend card card--interactive">
+            <span className="legend-item">
+              <span className="legend-indicator cell-weather">WEATHER</span> Postponed
+            </span>
+            <span className="legend-item">
+              <span className="legend-indicator cell-unknown">?</span> Not yet reported
+            </span>
+            <span className="legend-item">
+              <span className="legend-indicator cell-empty">{'\u2014'}</span> No data
+            </span>
+          </div>
+
+          {/* Score tables per night */}
+          {filteredNightKeys.map((key) => {
+            const group = nightGroups[key];
+            return (
+              <div key={key} className="scores-section">
+                <h2 className="scores-night-heading">{group.night} League</h2>
+                <div className="scores-table-card card card--interactive">
+                  <div className="table-responsive">
+                    <table className="scores-table">
+                      <thead>
+                        <tr>
+                          <th className="col-rank">#</th>
+                          <th className="col-team">Team</th>
+                          {weekColumns.map((week) => (
+                            <th key={week} className="col-week">
+                              {week}
+                            </th>
+                          ))}
+                          <th className="col-total">Total</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {group.teams.length === 0 ? (
+                          <tr className="empty-row">
+                            <td colSpan={weekColumns.length + 3}>
+                              No teams found for this night.
+                            </td>
+                          </tr>
+                        ) : (
+                          group.teams.map((team, index) => (
+                            <tr
+                              key={team['Team Name']}
+                              className={
+                                index === 0
+                                  ? 'leader'
+                                  : index < 3
+                                  ? 'top-three'
+                                  : ''
+                              }
+                            >
+                              <td data-label="#">{index + 1}</td>
+                              <td data-label="Team">{team['Team Name']}</td>
+                              {weekColumns.map((week) => {
+                                const cell = formatCellValue(team[week]);
+                                return (
+                                  <td
+                                    key={week}
+                                    data-label={week}
+                                    className={cell.className}
+                                    title={cell.title || undefined}
+                                  >
+                                    {cell.text}
+                                  </td>
+                                );
+                              })}
+                              <td data-label="Total" className="cell-total">
+                                {team['Total Points'] || '\u2014'}
+                              </td>
+                            </tr>
+                          ))
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+
+          {filteredNightKeys.length === 0 && (
+            <div className="empty-state card card--interactive">
+              <p>No leagues match the selected filter.</p>
+            </div>
+          )}
+        </>
+      )}
+    </main>
+  );
+};
+
+export { Scores };
+

--- a/src/styles/AddScore.css
+++ b/src/styles/AddScore.css
@@ -644,6 +644,30 @@
   gap: var(--space-sm);
 }
 
+.set-winner-select {
+  width: 100%;
+  background: var(--score-page-bg);
+  border: 1px solid var(--score-card-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  font-size: var(--font-size-sm);
+  color: var(--score-card-text);
+  font-weight: 600;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  background-size: 16px;
+  padding-right: 2.5rem;
+  cursor: pointer;
+}
+
+.set-winner-select:focus {
+  outline: none;
+  border-color: var(--score-accent);
+  box-shadow: 0 0 0 3px rgba(var(--color-secondary-rgb), 0.2);
+}
+
 .score-group label {
   font-size: var(--font-size-sm);
   font-weight: 600;

--- a/src/styles/Scores.css
+++ b/src/styles/Scores.css
@@ -1,0 +1,338 @@
+.scores-page {
+  --scores-page-bg: var(--bg-primary);
+  --scores-surface: var(--bg-secondary);
+  --scores-border: var(--border-primary);
+  --scores-text: var(--text-primary);
+  --scores-muted: var(--text-muted);
+  --scores-heading: var(--primary-green-dark);
+  --scores-accent: var(--primary-green);
+  --scores-header-bg: rgba(var(--color-primary-rgb), 0.12);
+  --scores-header-text: var(--text-primary);
+  --scores-stripe: rgba(var(--color-primary-rgb), 0.06);
+  --scores-row-hover: rgba(var(--color-primary-rgb), 0.14);
+  background: var(--scores-page-bg);
+  color: var(--scores-text);
+  min-height: 100vh;
+  padding: var(--space-2xl) var(--space-xl);
+  transition: background var(--transition-normal), color var(--transition-normal);
+}
+
+:root[data-theme="dark"] .scores-page {
+  --scores-page-bg: var(--bg-dark);
+  --scores-surface: rgba(var(--color-secondary-rgb), 0.12);
+  --scores-border: rgba(var(--color-secondary-rgb), 0.35);
+  --scores-text: var(--text-primary);
+  --scores-muted: var(--text-secondary);
+  --scores-heading: var(--secondary-light);
+  --scores-accent: var(--secondary-light);
+  --scores-header-bg: rgba(var(--color-secondary-rgb), 0.24);
+  --scores-header-text: var(--text-primary);
+  --scores-stripe: rgba(var(--color-secondary-rgb), 0.18);
+  --scores-row-hover: rgba(var(--color-secondary-rgb), 0.28);
+}
+
+
+/* Header */
+.scores-header {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto var(--space-2xl);
+}
+
+.scores-header h1 {
+  font-size: var(--font-size-4xl);
+  font-weight: 800;
+  color: var(--scores-heading);
+  margin-bottom: var(--space-sm);
+}
+
+.scores-header p {
+  margin: 0;
+  color: var(--scores-muted);
+  font-size: var(--font-size-lg);
+}
+
+/* Loading / Error / Empty states */
+.loading-state,
+.error-state,
+.empty-state {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: var(--space-xl);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.error-state p {
+  color: var(--error);
+  margin: 0;
+}
+
+/* Controls */
+.scores-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  padding: var(--space-lg);
+  margin-bottom: var(--space-xl);
+}
+
+.scores-controls-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  flex-wrap: wrap;
+}
+
+.controls-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.controls-title {
+  font-weight: 700;
+  font-size: var(--font-size-base);
+}
+
+.controls-subtitle {
+  color: var(--scores-muted);
+  font-size: var(--font-size-sm);
+}
+
+.night-filter-group {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.night-filter {
+  background: rgba(var(--color-primary-rgb), 0.1);
+  color: var(--scores-heading);
+  border: 1px solid rgba(var(--color-primary-rgb), 0.2);
+  border-radius: var(--radius-full);
+  padding: var(--space-sm) var(--space-lg);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast),
+    transform var(--transition-fast), border var(--transition-fast);
+}
+
+.night-filter:hover,
+.night-filter:focus-visible {
+  background: var(--scores-accent);
+  border-color: var(--scores-accent);
+  color: var(--text-inverse);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.night-filter.active {
+  background: var(--scores-accent);
+  border-color: var(--scores-accent);
+  color: var(--text-inverse);
+  box-shadow: var(--card-shadow);
+}
+
+.updated-at {
+  font-size: var(--font-size-xs);
+  color: var(--scores-muted);
+}
+
+/* Legend */
+.scores-legend {
+  display: flex;
+  gap: var(--space-lg);
+  padding: var(--space-md) var(--space-lg);
+  margin-bottom: var(--space-xl);
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: var(--font-size-sm);
+  color: var(--scores-muted);
+}
+
+.legend-indicator {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+}
+
+/* Score section */
+.scores-section {
+  margin-bottom: var(--space-2xl);
+}
+
+.scores-night-heading {
+  font-size: var(--font-size-2xl);
+  font-weight: 700;
+  color: var(--scores-accent);
+  margin-bottom: var(--space-md);
+}
+
+/* Score table */
+.scores-table-card {
+  padding: var(--space-lg);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table-responsive {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.scores-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+  background: var(--scores-surface);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.scores-table thead {
+  background: var(--scores-header-bg);
+  color: var(--scores-header-text);
+}
+
+.scores-table th,
+.scores-table td {
+  padding: calc(var(--space-sm) + 2px) var(--space-md);
+  text-align: left;
+  border-bottom: 1px solid var(--scores-border);
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+}
+
+.scores-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+}
+
+.scores-table .col-rank {
+  width: 4%;
+  text-align: center;
+}
+
+.scores-table .col-team {
+  min-width: 200px;
+}
+
+.scores-table .col-week {
+  width: 7%;
+  text-align: center;
+}
+
+.scores-table .col-total {
+  width: 7%;
+  text-align: center;
+  font-weight: 700;
+}
+
+.scores-table tbody tr {
+  transition: background var(--transition-fast);
+}
+
+.scores-table tbody tr:nth-child(even) td {
+  background: var(--scores-stripe);
+}
+
+.scores-table tbody tr:hover td {
+  background: var(--scores-row-hover);
+}
+
+.scores-table tbody tr.leader td {
+  background: rgba(var(--color-primary-rgb), 0.12);
+  font-weight: 700;
+}
+
+.scores-table tbody tr.top-three td:first-child {
+  color: var(--scores-accent);
+}
+
+.empty-row td {
+  text-align: center;
+  padding: var(--space-lg);
+  color: var(--scores-muted);
+}
+
+/* Cell styling */
+.cell-score {
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.cell-weather {
+  color: var(--warning, #d97706);
+  font-weight: 600;
+  text-align: center;
+  font-size: var(--font-size-xs);
+}
+
+.cell-unknown {
+  color: var(--scores-muted);
+  text-align: center;
+}
+
+.cell-empty {
+  color: var(--scores-muted);
+  text-align: center;
+  opacity: 0.5;
+}
+
+.cell-text {
+  text-align: center;
+}
+
+.cell-total {
+  text-align: center;
+  font-weight: 700;
+  color: var(--scores-accent);
+  font-size: var(--font-size-base);
+}
+
+/* Responsive */
+@media (max-width: 960px) {
+  .scores-page {
+    padding: var(--space-xl) var(--space-lg);
+  }
+
+  .scores-table {
+    min-width: 640px;
+  }
+}
+
+@media (max-width: 640px) {
+  .scores-page {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .scores-header h1 {
+    font-size: var(--font-size-3xl);
+  }
+
+  .scores-legend {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-sm);
+  }
+
+  .night-filter {
+    width: 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new **Scores** page that fetches and displays team weekly scores from the Google Sheets CSV endpoint.

### Changes
- **New:** `src/components/Scores.jsx` — React component that fetches, parses, and displays CSV data grouped by league night
- **New:** `src/styles/Scores.css` — Responsive styling matching existing patterns (cards, dark mode, filters)
- **Modified:** `src/App.jsx` — Added `/scores` route
- **Modified:** `src/components/Navigation.jsx` — Added `Scores` link in League dropdown

### Features
- Fetches CSV from Google Sheets published endpoint
- Groups teams by Tuesday/Wednesday league night
- Night filter tabs (All / Tuesday / Wednesday)
- Handles special values: WEATHER, ?, and empty cells
- Loading, error, and empty states with retry buttons
- Responsive tables with horizontal scroll on mobile
- Dark mode support
- Legend explaining cell value meanings

### CSV Source
`https://docs.google.com/spreadsheets/d/e/2PACX-1vTRXXJgqymosDbuyhAHCpHHUqQsNxRk0B-3kBGWr7CuPymhKUpT83JKyN7DxkCiaPdKsZEeBaA3GDjH/pub?gid=1910758219&single=true&output=csv`