### PR TITLE
fix(standings): force Safari asset reload via cache buster

### DIFF
--- a/pages/standings.html
+++ b/pages/standings.html
@@ -7,9 +7,9 @@
     <link rel="icon" href="../assets/logo192.png" />
     <link rel="apple-touch-icon" href="../assets/logo192.png" />
     <link rel="manifest" href="../manifest.json" />
-    <link rel="stylesheet" href="../styles/style.css?v=2026.9" />
-    <link rel="stylesheet" href="../styles/nav.css?v=2026.9" />
-    <link rel="stylesheet" href="../styles/standings.css" />
+    <link rel="stylesheet" href="../styles/style.css?v=2026.10" />
+    <link rel="stylesheet" href="../styles/nav.css?v=2026.10" />
+    <link rel="stylesheet" href="../styles/standings.css?v=2026.10" />
     <script src="https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js"></script>
     <style>
       .night-filter.active {
@@ -42,8 +42,8 @@
         <div class="loading">Loading standings&hellip;</div>
       </div>
     </main>
-    <script src="../scripts/nav.js?v=2026.9"></script>
-    <script src="../scripts/standings.js?v=2026.9"></script>
+    <script src="../scripts/nav.js?v=2026.10"></script>
+    <script src="../scripts/standings.js?v=2026.10"></script>
   </body>
 </html>
 


### PR DESCRIPTION
Increments cache buster query parameters in standings.html to force Safari to clear its local cache and fetch the new standings.js (containing Safari load fixes) and standings.css (containing desktop viewport scroll fixes).