### PR TITLE
feat(workflow): auto-increment cache buster on deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Fetch Weather Fallback Data
         run: node scripts/fetch-fallback-weather.js
 
+      - name: Auto-increment cache buster
+        run: node management-scripts/bump-version.js 2026.${{ github.run_number }}
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 


### PR DESCRIPTION
Integrates the existing bump-version.js script into the GitHub Actions deployment workflow. It automatically updates all asset cache-buster version parameters (e.g. ?v=2026.x) to 2026.<run_number> during build, ensuring cache invalidation on Safari and other browsers for every deploy.